### PR TITLE
No more node 15 schenanigans

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "release": "lerna publish",
     "release:canary": "lerna publish --canary",
     "shove": "git add -A; git commit -m 'chore(ci): test ci'; git push origin master",
-    "build:demo": "lerna run node15:build --stream"
+    "build:demo": "lerna run build --stream"
   },
   "husky": {
     "hooks": {

--- a/packages/bls12381/package-lock.json
+++ b/packages/bls12381/package-lock.json
@@ -1338,47 +1338,27 @@
 			}
 		},
 		"@mattrglobal/bbs-signatures": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@mattrglobal/bbs-signatures/-/bbs-signatures-0.4.0.tgz",
-			"integrity": "sha512-r6ed3N9xO+7AlO6FF2rVksH+HjfLwxZ9eKWHg3saTi5hzhJyehE3Qahj+goddgYD6emzwzrVbawNZDTttMQUKg==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@mattrglobal/bbs-signatures/-/bbs-signatures-0.5.0.tgz",
+			"integrity": "sha512-4te4TpacAmeCM8aa/kHkU0i1IJwsO1x/Tez6/YLUWg6rK6bfGA1NNO7IBc12u9ETkoTsiU32UmsiYWXcw9QwKQ==",
 			"requires": {
-				"@mattrglobal/node-bbs-signatures": "0.10.0"
+				"@mattrglobal/node-bbs-signatures": "0.11.0"
 			}
 		},
 		"@mattrglobal/bls12381-key-pair": {
-			"version": "0.5.1-unstable.e779976",
-			"resolved": "https://registry.npmjs.org/@mattrglobal/bls12381-key-pair/-/bls12381-key-pair-0.5.1-unstable.e779976.tgz",
-			"integrity": "sha512-npZhX59wqa6NyqEWFLVRQvnXRJhkESTHGCrvYFhKpesArZbWyLHx6TJKK4DYBjzBL5OWwpPlmB/Da0rMhK9Y8A==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@mattrglobal/bls12381-key-pair/-/bls12381-key-pair-0.5.0.tgz",
+			"integrity": "sha512-eXAtke0HOEr9RcT+NEI1MERE50gUnnLm1mYBJkUugk9REP3MfKXtX2Mo4FXyCH/IR4Oxj2jCcfNYW/h0Q3x5sg==",
 			"requires": {
 				"@mattrglobal/bbs-signatures": "0.5.0",
 				"bs58": "4.0.1",
 				"rfc4648": "1.4.0"
-			},
-			"dependencies": {
-				"@mattrglobal/bbs-signatures": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/@mattrglobal/bbs-signatures/-/bbs-signatures-0.5.0.tgz",
-					"integrity": "sha512-4te4TpacAmeCM8aa/kHkU0i1IJwsO1x/Tez6/YLUWg6rK6bfGA1NNO7IBc12u9ETkoTsiU32UmsiYWXcw9QwKQ==",
-					"requires": {
-						"@mattrglobal/node-bbs-signatures": "0.11.0"
-					}
-				},
-				"@mattrglobal/node-bbs-signatures": {
-					"version": "0.11.0",
-					"resolved": "https://registry.npmjs.org/@mattrglobal/node-bbs-signatures/-/node-bbs-signatures-0.11.0.tgz",
-					"integrity": "sha512-V0wcY0ZewrPOiMOrL3wam0oYL1SLbF2ihgAM6JQvLrAKw1MckYiJ8T4vL+nOBs2hf1PA1TZI+USe5mqMWuVKTw==",
-					"optional": true,
-					"requires": {
-						"neon-cli": "0.4.0",
-						"node-pre-gyp": "0.14.0"
-					}
-				}
 			}
 		},
 		"@mattrglobal/node-bbs-signatures": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/@mattrglobal/node-bbs-signatures/-/node-bbs-signatures-0.10.0.tgz",
-			"integrity": "sha512-i2sd61gXQJ0YJZ6JLUnKoQ8w+V39OOh5cdrYv0odnnF00H0a8y9JbSoDbzqEywFGol6oXk2ezFGI/ilU+1R7wQ==",
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@mattrglobal/node-bbs-signatures/-/node-bbs-signatures-0.11.0.tgz",
+			"integrity": "sha512-V0wcY0ZewrPOiMOrL3wam0oYL1SLbF2ihgAM6JQvLrAKw1MckYiJ8T4vL+nOBs2hf1PA1TZI+USe5mqMWuVKTw==",
 			"optional": true,
 			"requires": {
 				"neon-cli": "0.4.0",
@@ -8863,9 +8843,9 @@
 			"optional": true
 		},
 		"uglify-js": {
-			"version": "3.13.0",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.0.tgz",
-			"integrity": "sha512-TWYSWa9T2pPN4DIJYbU9oAjQx+5qdV5RUDxwARg8fmJZrD/V27Zj0JngW5xg1DFz42G0uDYl2XhzF6alSzD62w==",
+			"version": "3.13.4",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.4.tgz",
+			"integrity": "sha512-kv7fCkIXyQIilD5/yQy8O+uagsYIOt5cZvs890W40/e/rvjMSzJw81o9Bg0tkURxzZBROtDQhW2LFjOGoK3RZw==",
 			"optional": true
 		},
 		"unbox-primitive": {

--- a/packages/bls12381/package-lock.json
+++ b/packages/bls12381/package-lock.json
@@ -1443,12 +1443,6 @@
 				"picomatch": "^2.2.2"
 			}
 		},
-		"@transmute/did-key-test-vectors": {
-			"version": "0.2.1-unstable.37",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-test-vectors/-/did-key-test-vectors-0.2.1-unstable.37.tgz",
-			"integrity": "sha512-/v1+AEjd6lrqKxnYomtQ03Q4F6nePXF4G8LvNn9ncEd69Xvgg3O7pfI7BHjcPd3X6AcmQhHxOk5BHEzuUxZ1yQ==",
-			"dev": true
-		},
 		"@types/babel__core": {
 			"version": "7.1.12",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",

--- a/packages/bls12381/package.json
+++ b/packages/bls12381/package.json
@@ -36,8 +36,8 @@
     "typescript": "^3.9.5"
   },
   "dependencies": {
-    "@mattrglobal/bbs-signatures": "0.4.0",
-    "@mattrglobal/bls12381-key-pair": "^0.5.1-unstable.e779976",
+    "@mattrglobal/bbs-signatures": "^0.5.0",
+    "@mattrglobal/bls12381-key-pair": "^0.5.0",
     "base64url": "^3.0.1",
     "bs58": "^4.0.1"
   }

--- a/packages/create-react-app-sanity/package-lock.json
+++ b/packages/create-react-app-sanity/package-lock.json
@@ -1818,58 +1818,6 @@
 				}
 			}
 		},
-		"@peculiar/asn1-schema": {
-			"version": "2.0.27",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.0.27.tgz",
-			"integrity": "sha512-1tIx7iL3Ma3HtnNS93nB7nhyI0soUJypElj9owd4tpMrRDmeJ8eZubsdq1sb0KSaCs5RqZNoABCP6m5WtnlVhQ==",
-			"requires": {
-				"@types/asn1js": "^2.0.0",
-				"asn1js": "^2.0.26",
-				"pvtsutils": "^1.1.1",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-				}
-			}
-		},
-		"@peculiar/json-schema": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
-			"integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
-			"requires": {
-				"tslib": "^2.0.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-				}
-			}
-		},
-		"@peculiar/webcrypto": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.1.6.tgz",
-			"integrity": "sha512-xcTjouis4Y117mcsJslWAGypwhxtXslkVdRp7e3tHwtuw0/xCp1te8RuMMv/ia5TsvxomcyX/T+qTbRZGLLvyA==",
-			"requires": {
-				"@peculiar/asn1-schema": "^2.0.27",
-				"@peculiar/json-schema": "^1.1.12",
-				"pvtsutils": "^1.1.2",
-				"tslib": "^2.1.0",
-				"webcrypto-core": "^1.2.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-				}
-			}
-		},
 		"@pmmmwh/react-refresh-webpack-plugin": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.2.tgz",
@@ -1942,171 +1890,6 @@
 			"integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
 			"requires": {
 				"@sinonjs/commons": "^1.7.0"
-			}
-		},
-		"@stablelib/aead": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/aead/-/aead-1.0.0.tgz",
-			"integrity": "sha512-2iO0P15w1onK8g/m6ygNqlMFBfC7BM8o1Zr7jRqMAF9+zhhyY3h4NZwnXKxUm11TBm62Yeesw+FKqs/gJ6shMA=="
-		},
-		"@stablelib/aes": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/aes/-/aes-1.0.0.tgz",
-			"integrity": "sha512-nB6rZxdrbk6dmrHyzEW7u0VOUp1OEYSUmVw8FhAtR6Q91w5MGvwKOpeSoEUWkDLSWy/Hnaem9mV5lzMQJapIig==",
-			"requires": {
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/blockcipher": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/aes-kw": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/aes-kw/-/aes-kw-1.0.0.tgz",
-			"integrity": "sha512-7EYxUFlUbmEaBgVsrunskMpMDSAQL0D6WY4ImzohBGcx8xRR0o+6UiA+EgxTSvSaqnrMK3XmVwnloEl+1YIu7Q==",
-			"requires": {
-				"@stablelib/aes": "^1.0.0",
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/blockcipher": "^1.0.0",
-				"@stablelib/constant-time": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/binary": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.0.tgz",
-			"integrity": "sha512-W01QhOw1tWL51Du1c5JZphJs7toRbfra1C2DBlhT0mRHZWGWB1hpFbqiZUFY7QNIMUpmmHLrlZs3YsSCB/giUg==",
-			"requires": {
-				"@stablelib/int": "^1.0.0"
-			}
-		},
-		"@stablelib/blockcipher": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/blockcipher/-/blockcipher-1.0.0.tgz",
-			"integrity": "sha512-IQVA3XwCrXb2alpNm4L/MkHkR19f7kH3WmT1oJN6AZWnC7R0vNWKdxnf+4YyHSKisvXThwmyecLMGO+VSdRsDg=="
-		},
-		"@stablelib/bytes": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/bytes/-/bytes-1.0.0.tgz",
-			"integrity": "sha512-c9CfJwoZpxub6yicmhkeEpvLLsvsAP76tBAHEXKuEjPzza946U7bgebJJoMl8Q+ZlU2vy9ZoWCXE1uLpi817Pg=="
-		},
-		"@stablelib/chacha": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/chacha/-/chacha-1.0.0.tgz",
-			"integrity": "sha512-tlp3ECXiU7APq6n1YQ2K4B7MUppAOUWsvN1JMs2OWnYVR2Km+AsSmgMjjtefG8vPZ+J8tfY3sufzh5zCg5xiSw==",
-			"requires": {
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/chacha20poly1305": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/chacha20poly1305/-/chacha20poly1305-1.0.0.tgz",
-			"integrity": "sha512-sRv7T5nDRpwqerY9VZ3ABfzHukF/aa2njKvCHPvMpM3+WOYqU4JIP47MdvmrEj+NFHFP3hBx6XV5xpnV8IqMig==",
-			"requires": {
-				"@stablelib/aead": "^1.0.0",
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/chacha": "^1.0.0",
-				"@stablelib/constant-time": "^1.0.0",
-				"@stablelib/poly1305": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/constant-time": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.0.tgz",
-			"integrity": "sha512-0lH6SB0wP562fa0yvNZMF2NbFr8QHeefhO1KOu2unW8qH1npdep7I1vGbPqEM+BHg6LqllPceVE8Ca0RwIDLDA=="
-		},
-		"@stablelib/ed25519": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-1.0.1.tgz",
-			"integrity": "sha512-kvC98vkJeertRj37yqTcjOwUVYWQ0jcywxxWpeuTal5ZNgH7EcbljtQYECA2Pi2N0zNG0a0AjSD2Q2DFcUxRjQ==",
-			"requires": {
-				"@stablelib/random": "^1.0.0",
-				"@stablelib/sha512": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/hash": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-1.0.0.tgz",
-			"integrity": "sha512-wBvSIIx4Y8799BRD4TBhezS1P9+irGAKdsNgbZMeU5ndMbw7BtZALdCm0FcJIRFxJ2giPLPS9YCgrwWAhzSRLQ=="
-		},
-		"@stablelib/int": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.0.tgz",
-			"integrity": "sha512-MRigEQCO7xM93nZqW4CbIBjhANGw3jJxGVSUZH3PQ6HWL1IGrFWVDBzIclWxl4l5aRRpqoM+76ellQNdUJPnsA=="
-		},
-		"@stablelib/keyagreement": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/keyagreement/-/keyagreement-1.0.0.tgz",
-			"integrity": "sha512-M4f0QhuYGrMCLPoJIKWpC5riJfDivOFZHOAlj1Av44UJSyMzM46gJW0e9khKoTcbU8r8oXebkwlJT70Xm0+kqg==",
-			"requires": {
-				"@stablelib/bytes": "^1.0.0"
-			}
-		},
-		"@stablelib/poly1305": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/poly1305/-/poly1305-1.0.0.tgz",
-			"integrity": "sha512-8EOq8g3Naae+gGI/c/Tt1+xhbgDvkFwYx7QfTlps7SwA/IC6dhEZ+BzvU6O9FuVQ/l72yV7i3PSJ3LMOvTxS8g==",
-			"requires": {
-				"@stablelib/constant-time": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/random": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.0.tgz",
-			"integrity": "sha512-G9vwwKrNCGMI/uHL6XeWe2Nk4BuxkYyWZagGaDU9wrsuV+9hUwNI1lok2WVo8uJDa2zx7ahNwN7Ij983hOUFEw==",
-			"requires": {
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/sha512": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/sha512/-/sha512-1.0.0.tgz",
-			"integrity": "sha512-qvUu5SraAdGa8HAkAasfMyD9C+MwlRnFVRJ6cRxAEIekmDsU3tfGLnUm3wb9ao4t0FkihGrj8GKlV82TTR4Phw==",
-			"requires": {
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/hash": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/wipe": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.0.tgz",
-			"integrity": "sha512-0Fd4MQCbEh8OFSO+gG7wBXok7yRC3w+xe/wWM8KNye7EGoHr4BTFZNWV/1xAn2r8/gyFKxPXT8uxXRzDzGq6rg=="
-		},
-		"@stablelib/x25519": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/x25519/-/x25519-1.0.0.tgz",
-			"integrity": "sha512-sjlOzC8eZJhHTuMZnSTxtawYXbFXZtHm6TbhacvoYmJOG9/3cFX5z1Aw0WZfQvPNSk+8aPrpwuyRMmUO1PW8yw==",
-			"requires": {
-				"@stablelib/keyagreement": "^1.0.0",
-				"@stablelib/random": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/xchacha20": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/xchacha20/-/xchacha20-1.0.0.tgz",
-			"integrity": "sha512-8q98HxPCgVUGMnjMl79KhEtWsh0UQbTt5x1570QnynF3uzzsGgP7exXwkyqi7s85SdvdO8EKEezDMjuzqv69Yw==",
-			"requires": {
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/chacha": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/xchacha20poly1305": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/xchacha20poly1305/-/xchacha20poly1305-1.0.0.tgz",
-			"integrity": "sha512-rVcKmgEeMK8kInx2bvvBXLL/wMKrqeA6luWiZYRQj1QMnZnq3ReZd1szZdz2QWFQOlp7rXsZp+EaM4FqNlfZSw==",
-			"requires": {
-				"@stablelib/aead": "^1.0.0",
-				"@stablelib/chacha20poly1305": "^1.0.0",
-				"@stablelib/constant-time": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0",
-				"@stablelib/xchacha20": "^1.0.0"
 			}
 		},
 		"@surma/rollup-plugin-off-main-thread": {
@@ -2388,58 +2171,6 @@
 				"@babel/runtime": "^7.10.2"
 			}
 		},
-		"@transmute/did-key-cipher": {
-			"version": "0.2.1-unstable.37",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-cipher/-/did-key-cipher-0.2.1-unstable.37.tgz",
-			"integrity": "sha512-fEIfTUMo8XIDs7JJA0LIsgMkm4295YFb4qhA2zdpZBr/E5sA+GKJyK7DlUg8HTYH3hXjBGFyGO/j6xYr4xrTxA==",
-			"requires": {
-				"@peculiar/webcrypto": "^1.1.3",
-				"@stablelib/aes-kw": "^1.0.0",
-				"@stablelib/xchacha20poly1305": "^1.0.0",
-				"@transmute/did-key-common": "^0.2.1-unstable.37",
-				"web-streams-polyfill": "^3.0.0"
-			}
-		},
-		"@transmute/did-key-common": {
-			"version": "0.2.1-unstable.37",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-common/-/did-key-common-0.2.1-unstable.37.tgz",
-			"integrity": "sha512-oywMi4xQH1F1h2pJ9DNRZFyEWsy0R/R7dbeQHVz4W2gGJNQADY2pskk7atlvupAuU8n3SqlLkSn672YWGZlU7w==",
-			"requires": {
-				"base64url": "^3.0.1",
-				"borc": "^2.1.2",
-				"canonicalize": "^1.0.3",
-				"cbor": "^5.1.0"
-			}
-		},
-		"@transmute/did-key-ed25519": {
-			"version": "0.2.1-unstable.37",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-ed25519/-/did-key-ed25519-0.2.1-unstable.37.tgz",
-			"integrity": "sha512-subU+Hi3ICdoPBxZQ0M7C26HddNWLiNYjVoABvgkChZYpyVwAc25xsY72shLcxQlOz+FQh1ykeAb3qHsMwFHYA==",
-			"requires": {
-				"@stablelib/ed25519": "^1.0.1",
-				"@transmute/did-key-common": "^0.2.1-unstable.37",
-				"@transmute/did-key-x25519": "^0.2.1-unstable.37",
-				"@trust/keyto": "^1.0.1",
-				"base64url": "^3.0.1",
-				"bs58": "^4.0.1",
-				"canonicalize": "^1.0.1"
-			}
-		},
-		"@transmute/did-key-x25519": {
-			"version": "0.2.1-unstable.37",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-x25519/-/did-key-x25519-0.2.1-unstable.37.tgz",
-			"integrity": "sha512-sSBpiICDTEckJwMGxR83rqVR4S+6NTUet+S3VjXla/GZbT54oWgJu8uPmhUuyupxKrNyL5XbCdzp7BCZW6PJNg==",
-			"requires": {
-				"@stablelib/ed25519": "^1.0.1",
-				"@stablelib/x25519": "^1.0.0",
-				"@transmute/did-key-cipher": "^0.2.1-unstable.37",
-				"@transmute/did-key-common": "^0.2.1-unstable.37",
-				"@trust/keyto": "^1.0.1",
-				"base64url": "^3.0.1",
-				"bs58": "^4.0.1",
-				"canonicalize": "^1.0.1"
-			}
-		},
 		"@transmute/ed25519-signature-2018": {
 			"version": "0.1.1-unstable.11",
 			"resolved": "https://registry.npmjs.org/@transmute/ed25519-signature-2018/-/ed25519-signature-2018-0.1.1-unstable.11.tgz",
@@ -2513,16 +2244,6 @@
 				}
 			}
 		},
-		"@trust/keyto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@trust/keyto/-/keyto-1.0.1.tgz",
-			"integrity": "sha512-OXTmKkrnkwktCX86XA7eWs1TQ6u64enm0syzAfNhjigbuGLy5aLhbhRYWtjt4zzdG/irWudluheRZ9Ic9pCwsA==",
-			"requires": {
-				"asn1.js": "^5.2.0",
-				"base64url": "^3.0.1",
-				"elliptic": "^6.5.2"
-			}
-		},
 		"@types/anymatch": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -2532,11 +2253,6 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
 			"integrity": "sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A=="
-		},
-		"@types/asn1js": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@types/asn1js/-/asn1js-2.0.0.tgz",
-			"integrity": "sha512-Jjzp5EqU0hNpADctc/UqhiFbY1y2MqIxBVa2S4dBlbnZHTLPMuggoL5q43X63LpsOIINRDirBjP56DUUKIUWIA=="
 		},
 		"@types/babel__core": {
 			"version": "7.1.12",
@@ -3281,14 +2997,6 @@
 				}
 			}
 		},
-		"asn1js": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.1.1.tgz",
-			"integrity": "sha512-t9u0dU0rJN4ML+uxgN6VM2Z4H5jWIYm0w8LsZLzMJaQsgL3IJNbxHgmbWDvJAwspyHpDFuzUaUFh4c05UB4+6g==",
-			"requires": {
-				"pvutils": "^1.0.17"
-			}
-		},
 		"assert": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
@@ -3809,11 +3517,6 @@
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
 			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
 		},
-		"bignumber.js": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-			"integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
-		},
 		"binary-extensions": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
@@ -3898,36 +3601,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
 			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
-		},
-		"borc": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
-			"integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
-			"requires": {
-				"bignumber.js": "^9.0.0",
-				"buffer": "^5.5.0",
-				"commander": "^2.15.0",
-				"ieee754": "^1.1.13",
-				"iso-url": "~0.4.7",
-				"json-text-sequence": "~0.1.0",
-				"readable-stream": "^3.6.0"
-			},
-			"dependencies": {
-				"buffer": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-					"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-					"requires": {
-						"base64-js": "^1.3.1",
-						"ieee754": "^1.1.13"
-					}
-				},
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-				}
-			}
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -4248,15 +3921,6 @@
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-		},
-		"cbor": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
-			"integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
-			"requires": {
-				"bignumber.js": "^9.0.1",
-				"nofilter": "^1.0.4"
-			}
 		},
 		"chalk": {
 			"version": "2.4.2",
@@ -5339,11 +5003,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-		},
-		"delimit-stream": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-			"integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
 		},
 		"depd": {
 			"version": "1.1.2",
@@ -8381,11 +8040,6 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
-		"iso-url": {
-			"version": "0.4.7",
-			"resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
-			"integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog=="
-		},
 		"isobject": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -10024,14 +9678,6 @@
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
-		"json-text-sequence": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-			"integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
-			"requires": {
-				"delimit-stream": "0.1.0"
-			}
-		},
 		"json3": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
@@ -10973,11 +10619,6 @@
 			"version": "1.1.66",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.66.tgz",
 			"integrity": "sha512-JHEQ1iWPGK+38VLB2H9ef2otU4l8s3yAMt9Xf934r6+ojCYDMHPMqvCc9TnzfeFSP1QEOeU6YZEd3+De0LTCgg=="
-		},
-		"nofilter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
-			"integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA=="
 		},
 		"normalize-package-data": {
 			"version": "2.5.0",
@@ -12817,26 +12458,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-		},
-		"pvtsutils": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.1.2.tgz",
-			"integrity": "sha512-Yfm9Dsk1zfEpOWCaJaHfqtNXAFWNNHMFSCLN6jTnhuCCBCC2nqge4sAgo7UrkRBoAAYIL8TN/6LlLoNfZD/b5A==",
-			"requires": {
-				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-				}
-			}
-		},
-		"pvutils": {
-			"version": "1.0.17",
-			"resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.0.17.tgz",
-			"integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ=="
 		},
 		"q": {
 			"version": "1.5.1",
@@ -16088,34 +15709,10 @@
 				"minimalistic-assert": "^1.0.0"
 			}
 		},
-		"web-streams-polyfill": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.0.3.tgz",
-			"integrity": "sha512-d2H/t0eqRNM4w2WvmTdoeIvzAUSpK7JmATB8Nr2lb7nQ9BTIJVjbQ/TRFVEh2gUH1HwclPdoPtfMoFfetXaZnA=="
-		},
 		"web-vitals": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-0.2.4.tgz",
 			"integrity": "sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg=="
-		},
-		"webcrypto-core": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.2.0.tgz",
-			"integrity": "sha512-p76Z/YLuE4CHCRdc49FB/ETaM4bzM3roqWNJeGs+QNY1fOTzKTOVnhmudW1fuO+5EZg6/4LG9NJ6gaAyxTk9XQ==",
-			"requires": {
-				"@peculiar/asn1-schema": "^2.0.27",
-				"@peculiar/json-schema": "^1.1.12",
-				"asn1js": "^2.0.26",
-				"pvtsutils": "^1.1.2",
-				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-				}
-			}
 		},
 		"webidl-conversions": {
 			"version": "6.1.0",

--- a/packages/did-key-cipher/package-lock.json
+++ b/packages/did-key-cipher/package-lock.json
@@ -1501,17 +1501,6 @@
 				"@stablelib/xchacha20": "^1.0.0"
 			}
 		},
-		"@transmute/did-key-common": {
-			"version": "0.2.1-unstable.36",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-common/-/did-key-common-0.2.1-unstable.36.tgz",
-			"integrity": "sha512-NvQC5CWPBVh3uj40LrRV2yGCUO9OMR4xeHRqbTxBnyIRwelfE5kL7KZoNo4E7e15Kao4X+evorG94wjBXR8iwA==",
-			"requires": {
-				"base64url": "^3.0.1",
-				"borc": "^2.1.2",
-				"canonicalize": "^1.0.3",
-				"cbor": "^5.1.0"
-			}
-		},
 		"@types/asn1js": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/@types/asn1js/-/asn1js-0.0.1.tgz",
@@ -2460,12 +2449,15 @@
 		"base64-js": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+			"dev": true,
+			"optional": true
 		},
 		"base64url": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
-			"integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
+			"integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+			"dev": true
 		},
 		"base64url-universal": {
 			"version": "1.1.0",
@@ -2493,11 +2485,6 @@
 				}
 			}
 		},
-		"bignumber.js": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-			"integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
-		},
 		"bindings": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -2506,20 +2493,6 @@
 			"optional": true,
 			"requires": {
 				"file-uri-to-path": "1.0.0"
-			}
-		},
-		"borc": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
-			"integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
-			"requires": {
-				"bignumber.js": "^9.0.0",
-				"buffer": "^5.5.0",
-				"commander": "^2.15.0",
-				"ieee754": "^1.1.13",
-				"iso-url": "~0.4.7",
-				"json-text-sequence": "~0.1.0",
-				"readable-stream": "^3.6.0"
 			}
 		},
 		"brace-expansion": {
@@ -2614,15 +2587,6 @@
 				"node-int64": "^0.4.0"
 			}
 		},
-		"buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"requires": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
-			}
-		},
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -2680,11 +2644,6 @@
 			"integrity": "sha512-54xKQZTqZrKVHmVz0+UvdZR6kQc7pJDgfhsMYDG19ID1BWoNnDMFm5Q3uSBSU401pBvKYMsHAt9qhEDcxmk8aw==",
 			"dev": true
 		},
-		"canonicalize": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.5.tgz",
-			"integrity": "sha512-mAjKJPIyP0xqqv6IAkvso07StOmz6cmGtNDg3pXCSzXVZOqka7StIkAhJl/zHOi4M2CgpYfD6aeRWbnrmtvBEA=="
-		},
 		"capture-exit": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -2699,15 +2658,6 @@
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 			"dev": true
-		},
-		"cbor": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
-			"integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
-			"requires": {
-				"bignumber.js": "^9.0.1",
-				"nofilter": "^1.0.4"
-			}
 		},
 		"chalk": {
 			"version": "2.4.2",
@@ -2870,7 +2820,8 @@
 		"commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true
 		},
 		"commondir": {
 			"version": "1.0.1",
@@ -3139,11 +3090,6 @@
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 			"dev": true
-		},
-		"delimit-stream": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-			"integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
 		},
 		"detect-newline": {
 			"version": "2.1.0",
@@ -4446,11 +4392,6 @@
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
-		"ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-		},
 		"ignore": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -4550,7 +4491,8 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
 		},
 		"inquirer": {
 			"version": "7.3.3",
@@ -4921,11 +4863,6 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 			"dev": true
-		},
-		"iso-url": {
-			"version": "0.4.7",
-			"resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
-			"integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog=="
 		},
 		"isobject": {
 			"version": "3.0.1",
@@ -5700,14 +5637,6 @@
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 			"dev": true
 		},
-		"json-text-sequence": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-			"integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
-			"requires": {
-				"delimit-stream": "0.1.0"
-			}
-		},
 		"json5": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
@@ -6358,11 +6287,6 @@
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.61.tgz",
 			"integrity": "sha512-DD5vebQLg8jLCOzwupn954fbIiZht05DAZs0k2u8NStSe6h9XdsuIQL8hSRKYiU8WUQRznmSDrKGbv3ObOmC7g==",
 			"dev": true
-		},
-		"nofilter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
-			"integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA=="
 		},
 		"normalize-package-data": {
 			"version": "2.5.0",
@@ -7069,16 +6993,6 @@
 			"requires": {
 				"find-up": "^2.0.0",
 				"read-pkg": "^2.0.0"
-			}
-		},
-		"readable-stream": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-			"requires": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
 			}
 		},
 		"realpath-native": {
@@ -8131,21 +8045,6 @@
 				}
 			}
 		},
-		"string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"requires": {
-				"safe-buffer": "~5.2.0"
-			},
-			"dependencies": {
-				"safe-buffer": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-				}
-			}
-		},
 		"strip-ansi": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -8821,11 +8720,6 @@
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
 			"dev": true
-		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"util.promisify": {
 			"version": "1.0.1",

--- a/packages/did-key-web-crypto/package-lock.json
+++ b/packages/did-key-web-crypto/package-lock.json
@@ -1784,6 +1784,37 @@
 				"fastq": "^1.6.0"
 			}
 		},
+		"@peculiar/asn1-schema": {
+			"version": "2.0.27",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.0.27.tgz",
+			"integrity": "sha512-1tIx7iL3Ma3HtnNS93nB7nhyI0soUJypElj9owd4tpMrRDmeJ8eZubsdq1sb0KSaCs5RqZNoABCP6m5WtnlVhQ==",
+			"requires": {
+				"@types/asn1js": "^2.0.0",
+				"asn1js": "^2.0.26",
+				"pvtsutils": "^1.1.1",
+				"tslib": "^2.0.3"
+			}
+		},
+		"@peculiar/json-schema": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+			"integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+			"requires": {
+				"tslib": "^2.0.0"
+			}
+		},
+		"@peculiar/webcrypto": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.1.6.tgz",
+			"integrity": "sha512-xcTjouis4Y117mcsJslWAGypwhxtXslkVdRp7e3tHwtuw0/xCp1te8RuMMv/ia5TsvxomcyX/T+qTbRZGLLvyA==",
+			"requires": {
+				"@peculiar/asn1-schema": "^2.0.27",
+				"@peculiar/json-schema": "^1.1.12",
+				"pvtsutils": "^1.1.2",
+				"tslib": "^2.1.0",
+				"webcrypto-core": "^1.2.0"
+			}
+		},
 		"@polka/url": {
 			"version": "1.0.0-next.11",
 			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.11.tgz",
@@ -1907,9 +1938,17 @@
 			}
 		},
 		"@transmute/web-crypto-key-pair": {
-			"version": "0.0.4-unstable.13",
-			"resolved": "https://registry.npmjs.org/@transmute/web-crypto-key-pair/-/web-crypto-key-pair-0.0.4-unstable.13.tgz",
-			"integrity": "sha512-ezCGDsf92gpXtkMvU2r62cLoLUWBwL0xD4cbhTQnuQc0nhMHtQRQ/dEDfuxXw1885LVdcaDlYvR/5g6w5xALQQ=="
+			"version": "0.6.1-unstable.18",
+			"resolved": "https://registry.npmjs.org/@transmute/web-crypto-key-pair/-/web-crypto-key-pair-0.6.1-unstable.18.tgz",
+			"integrity": "sha512-ohcB4V7DG3Mu/qR0uyggtFVg6b/rTTZ3vpj81nnoEQXqrgRLetnWikIJT5ILHvt8eD0sn5mDlLEx/9BoD5543w==",
+			"requires": {
+				"@peculiar/webcrypto": "^1.1.6"
+			}
+		},
+		"@types/asn1js": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/asn1js/-/asn1js-2.0.0.tgz",
+			"integrity": "sha512-Jjzp5EqU0hNpADctc/UqhiFbY1y2MqIxBVa2S4dBlbnZHTLPMuggoL5q43X63LpsOIINRDirBjP56DUUKIUWIA=="
 		},
 		"@types/babel__core": {
 			"version": "7.1.12",
@@ -2591,6 +2630,14 @@
 					"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
 					"dev": true
 				}
+			}
+		},
+		"asn1js": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.1.1.tgz",
+			"integrity": "sha512-t9u0dU0rJN4ML+uxgN6VM2Z4H5jWIYm0w8LsZLzMJaQsgL3IJNbxHgmbWDvJAwspyHpDFuzUaUFh4c05UB4+6g==",
+			"requires": {
+				"pvutils": "^1.0.17"
 			}
 		},
 		"assert": {
@@ -10867,6 +10914,19 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
+		"pvtsutils": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.1.2.tgz",
+			"integrity": "sha512-Yfm9Dsk1zfEpOWCaJaHfqtNXAFWNNHMFSCLN6jTnhuCCBCC2nqge4sAgo7UrkRBoAAYIL8TN/6LlLoNfZD/b5A==",
+			"requires": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"pvutils": {
+			"version": "1.0.17",
+			"resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.0.17.tgz",
+			"integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ=="
+		},
 		"q": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -13213,8 +13273,7 @@
 		"tslib": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-			"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-			"dev": true
+			"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
 		},
 		"tsutils": {
 			"version": "3.20.0",
@@ -13742,6 +13801,18 @@
 			"dev": true,
 			"requires": {
 				"defaults": "^1.0.3"
+			}
+		},
+		"webcrypto-core": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.2.0.tgz",
+			"integrity": "sha512-p76Z/YLuE4CHCRdc49FB/ETaM4bzM3roqWNJeGs+QNY1fOTzKTOVnhmudW1fuO+5EZg6/4LG9NJ6gaAyxTk9XQ==",
+			"requires": {
+				"@peculiar/asn1-schema": "^2.0.27",
+				"@peculiar/json-schema": "^1.1.12",
+				"asn1js": "^2.0.26",
+				"pvtsutils": "^1.1.2",
+				"tslib": "^2.1.0"
 			}
 		},
 		"webidl-conversions": {

--- a/packages/did-key-web-crypto/package.json
+++ b/packages/did-key-web-crypto/package.json
@@ -56,6 +56,6 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
-    "@transmute/web-crypto-key-pair": "^0.0.4-unstable.13"
+    "@transmute/web-crypto-key-pair": "^0.6.1-unstable.18"
   }
 }

--- a/packages/did-key-web-crypto/package.json
+++ b/packages/did-key-web-crypto/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "start": "tsdx watch",
     "build": "tsdx build",
-    "test": "TS_JEST_DISABLE_VER_CHECKER=true tsdx test --passWithNoTests",
+    "test": "tsdx test --passWithNoTests",
     "lint": "tsdx lint src --fix",
     "prepare": "tsdx build",
     "size": "size-limit",

--- a/packages/did-key-web-crypto/package.json
+++ b/packages/did-key-web-crypto/package.json
@@ -24,10 +24,10 @@
   },
   "scripts": {
     "start": "tsdx watch",
-    "node15:build": "tsdx build",
-    "node15:test": "TS_JEST_DISABLE_VER_CHECKER=true tsdx test --passWithNoTests",
-    "node15:lint": "tsdx lint src --fix",
-    "node15:prepare": "tsdx build",
+    "build": "tsdx build",
+    "test": "TS_JEST_DISABLE_VER_CHECKER=true tsdx test --passWithNoTests",
+    "lint": "tsdx lint src --fix",
+    "prepare": "tsdx build",
     "size": "size-limit",
     "analyze": "size-limit --why"
   },

--- a/packages/did-key-web-crypto/src/index.ts
+++ b/packages/did-key-web-crypto/src/index.ts
@@ -1,2 +1,4 @@
+import * as driver from './driver';
+
 export * from './KeyPair';
-export * as driver from './driver'
+export { driver };

--- a/packages/did-key.js/package-lock.json
+++ b/packages/did-key.js/package-lock.json
@@ -1304,99 +1304,6 @@
 				"@types/yargs": "^13.0.0"
 			}
 		},
-		"@mattrglobal/bbs-signatures": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@mattrglobal/bbs-signatures/-/bbs-signatures-0.4.0.tgz",
-			"integrity": "sha512-r6ed3N9xO+7AlO6FF2rVksH+HjfLwxZ9eKWHg3saTi5hzhJyehE3Qahj+goddgYD6emzwzrVbawNZDTttMQUKg==",
-			"requires": {
-				"@mattrglobal/node-bbs-signatures": "0.10.0"
-			}
-		},
-		"@mattrglobal/bls12381-key-pair": {
-			"version": "0.5.1-unstable.e779976",
-			"resolved": "https://registry.npmjs.org/@mattrglobal/bls12381-key-pair/-/bls12381-key-pair-0.5.1-unstable.e779976.tgz",
-			"integrity": "sha512-npZhX59wqa6NyqEWFLVRQvnXRJhkESTHGCrvYFhKpesArZbWyLHx6TJKK4DYBjzBL5OWwpPlmB/Da0rMhK9Y8A==",
-			"requires": {
-				"@mattrglobal/bbs-signatures": "0.5.0",
-				"bs58": "4.0.1",
-				"rfc4648": "1.4.0"
-			},
-			"dependencies": {
-				"@mattrglobal/bbs-signatures": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/@mattrglobal/bbs-signatures/-/bbs-signatures-0.5.0.tgz",
-					"integrity": "sha512-4te4TpacAmeCM8aa/kHkU0i1IJwsO1x/Tez6/YLUWg6rK6bfGA1NNO7IBc12u9ETkoTsiU32UmsiYWXcw9QwKQ==",
-					"requires": {
-						"@mattrglobal/node-bbs-signatures": "0.11.0"
-					}
-				},
-				"@mattrglobal/node-bbs-signatures": {
-					"version": "0.11.0",
-					"resolved": "https://registry.npmjs.org/@mattrglobal/node-bbs-signatures/-/node-bbs-signatures-0.11.0.tgz",
-					"integrity": "sha512-V0wcY0ZewrPOiMOrL3wam0oYL1SLbF2ihgAM6JQvLrAKw1MckYiJ8T4vL+nOBs2hf1PA1TZI+USe5mqMWuVKTw==",
-					"optional": true,
-					"requires": {
-						"neon-cli": "0.4.0",
-						"node-pre-gyp": "0.14.0"
-					}
-				}
-			}
-		},
-		"@mattrglobal/node-bbs-signatures": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/@mattrglobal/node-bbs-signatures/-/node-bbs-signatures-0.10.0.tgz",
-			"integrity": "sha512-i2sd61gXQJ0YJZ6JLUnKoQ8w+V39OOh5cdrYv0odnnF00H0a8y9JbSoDbzqEywFGol6oXk2ezFGI/ilU+1R7wQ==",
-			"optional": true,
-			"requires": {
-				"neon-cli": "0.4.0",
-				"node-pre-gyp": "0.14.0"
-			}
-		},
-		"@peculiar/asn1-schema": {
-			"version": "2.0.27",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.0.27.tgz",
-			"integrity": "sha512-1tIx7iL3Ma3HtnNS93nB7nhyI0soUJypElj9owd4tpMrRDmeJ8eZubsdq1sb0KSaCs5RqZNoABCP6m5WtnlVhQ==",
-			"requires": {
-				"@types/asn1js": "^2.0.0",
-				"asn1js": "^2.0.26",
-				"pvtsutils": "^1.1.1",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-				}
-			}
-		},
-		"@peculiar/json-schema": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
-			"integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
-			"requires": {
-				"tslib": "^2.0.0"
-			}
-		},
-		"@peculiar/webcrypto": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.1.6.tgz",
-			"integrity": "sha512-xcTjouis4Y117mcsJslWAGypwhxtXslkVdRp7e3tHwtuw0/xCp1te8RuMMv/ia5TsvxomcyX/T+qTbRZGLLvyA==",
-			"requires": {
-				"@peculiar/asn1-schema": "^2.0.27",
-				"@peculiar/json-schema": "^1.1.12",
-				"pvtsutils": "^1.1.2",
-				"tslib": "^2.1.0",
-				"webcrypto-core": "^1.2.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-				}
-			}
-		},
 		"@rollup/plugin-commonjs": {
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-11.1.0.tgz",
@@ -1454,281 +1361,6 @@
 				"estree-walker": "^1.0.1",
 				"picomatch": "^2.2.2"
 			}
-		},
-		"@stablelib/aead": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/aead/-/aead-1.0.0.tgz",
-			"integrity": "sha512-2iO0P15w1onK8g/m6ygNqlMFBfC7BM8o1Zr7jRqMAF9+zhhyY3h4NZwnXKxUm11TBm62Yeesw+FKqs/gJ6shMA=="
-		},
-		"@stablelib/aes": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/aes/-/aes-1.0.0.tgz",
-			"integrity": "sha512-nB6rZxdrbk6dmrHyzEW7u0VOUp1OEYSUmVw8FhAtR6Q91w5MGvwKOpeSoEUWkDLSWy/Hnaem9mV5lzMQJapIig==",
-			"requires": {
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/blockcipher": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/aes-kw": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/aes-kw/-/aes-kw-1.0.0.tgz",
-			"integrity": "sha512-7EYxUFlUbmEaBgVsrunskMpMDSAQL0D6WY4ImzohBGcx8xRR0o+6UiA+EgxTSvSaqnrMK3XmVwnloEl+1YIu7Q==",
-			"requires": {
-				"@stablelib/aes": "^1.0.0",
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/blockcipher": "^1.0.0",
-				"@stablelib/constant-time": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/binary": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.0.tgz",
-			"integrity": "sha512-W01QhOw1tWL51Du1c5JZphJs7toRbfra1C2DBlhT0mRHZWGWB1hpFbqiZUFY7QNIMUpmmHLrlZs3YsSCB/giUg==",
-			"requires": {
-				"@stablelib/int": "^1.0.0"
-			}
-		},
-		"@stablelib/blockcipher": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/blockcipher/-/blockcipher-1.0.0.tgz",
-			"integrity": "sha512-IQVA3XwCrXb2alpNm4L/MkHkR19f7kH3WmT1oJN6AZWnC7R0vNWKdxnf+4YyHSKisvXThwmyecLMGO+VSdRsDg=="
-		},
-		"@stablelib/bytes": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/bytes/-/bytes-1.0.0.tgz",
-			"integrity": "sha512-c9CfJwoZpxub6yicmhkeEpvLLsvsAP76tBAHEXKuEjPzza946U7bgebJJoMl8Q+ZlU2vy9ZoWCXE1uLpi817Pg=="
-		},
-		"@stablelib/chacha": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/chacha/-/chacha-1.0.0.tgz",
-			"integrity": "sha512-tlp3ECXiU7APq6n1YQ2K4B7MUppAOUWsvN1JMs2OWnYVR2Km+AsSmgMjjtefG8vPZ+J8tfY3sufzh5zCg5xiSw==",
-			"requires": {
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/chacha20poly1305": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/chacha20poly1305/-/chacha20poly1305-1.0.0.tgz",
-			"integrity": "sha512-sRv7T5nDRpwqerY9VZ3ABfzHukF/aa2njKvCHPvMpM3+WOYqU4JIP47MdvmrEj+NFHFP3hBx6XV5xpnV8IqMig==",
-			"requires": {
-				"@stablelib/aead": "^1.0.0",
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/chacha": "^1.0.0",
-				"@stablelib/constant-time": "^1.0.0",
-				"@stablelib/poly1305": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/constant-time": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.0.tgz",
-			"integrity": "sha512-0lH6SB0wP562fa0yvNZMF2NbFr8QHeefhO1KOu2unW8qH1npdep7I1vGbPqEM+BHg6LqllPceVE8Ca0RwIDLDA=="
-		},
-		"@stablelib/ed25519": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-1.0.1.tgz",
-			"integrity": "sha512-kvC98vkJeertRj37yqTcjOwUVYWQ0jcywxxWpeuTal5ZNgH7EcbljtQYECA2Pi2N0zNG0a0AjSD2Q2DFcUxRjQ==",
-			"requires": {
-				"@stablelib/random": "^1.0.0",
-				"@stablelib/sha512": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/hash": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-1.0.0.tgz",
-			"integrity": "sha512-wBvSIIx4Y8799BRD4TBhezS1P9+irGAKdsNgbZMeU5ndMbw7BtZALdCm0FcJIRFxJ2giPLPS9YCgrwWAhzSRLQ=="
-		},
-		"@stablelib/int": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.0.tgz",
-			"integrity": "sha512-MRigEQCO7xM93nZqW4CbIBjhANGw3jJxGVSUZH3PQ6HWL1IGrFWVDBzIclWxl4l5aRRpqoM+76ellQNdUJPnsA=="
-		},
-		"@stablelib/keyagreement": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/keyagreement/-/keyagreement-1.0.0.tgz",
-			"integrity": "sha512-M4f0QhuYGrMCLPoJIKWpC5riJfDivOFZHOAlj1Av44UJSyMzM46gJW0e9khKoTcbU8r8oXebkwlJT70Xm0+kqg==",
-			"requires": {
-				"@stablelib/bytes": "^1.0.0"
-			}
-		},
-		"@stablelib/poly1305": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/poly1305/-/poly1305-1.0.0.tgz",
-			"integrity": "sha512-8EOq8g3Naae+gGI/c/Tt1+xhbgDvkFwYx7QfTlps7SwA/IC6dhEZ+BzvU6O9FuVQ/l72yV7i3PSJ3LMOvTxS8g==",
-			"requires": {
-				"@stablelib/constant-time": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/random": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.0.tgz",
-			"integrity": "sha512-G9vwwKrNCGMI/uHL6XeWe2Nk4BuxkYyWZagGaDU9wrsuV+9hUwNI1lok2WVo8uJDa2zx7ahNwN7Ij983hOUFEw==",
-			"requires": {
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/sha512": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/sha512/-/sha512-1.0.0.tgz",
-			"integrity": "sha512-qvUu5SraAdGa8HAkAasfMyD9C+MwlRnFVRJ6cRxAEIekmDsU3tfGLnUm3wb9ao4t0FkihGrj8GKlV82TTR4Phw==",
-			"requires": {
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/hash": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/wipe": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.0.tgz",
-			"integrity": "sha512-0Fd4MQCbEh8OFSO+gG7wBXok7yRC3w+xe/wWM8KNye7EGoHr4BTFZNWV/1xAn2r8/gyFKxPXT8uxXRzDzGq6rg=="
-		},
-		"@stablelib/x25519": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/x25519/-/x25519-1.0.0.tgz",
-			"integrity": "sha512-sjlOzC8eZJhHTuMZnSTxtawYXbFXZtHm6TbhacvoYmJOG9/3cFX5z1Aw0WZfQvPNSk+8aPrpwuyRMmUO1PW8yw==",
-			"requires": {
-				"@stablelib/keyagreement": "^1.0.0",
-				"@stablelib/random": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/xchacha20": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/xchacha20/-/xchacha20-1.0.0.tgz",
-			"integrity": "sha512-8q98HxPCgVUGMnjMl79KhEtWsh0UQbTt5x1570QnynF3uzzsGgP7exXwkyqi7s85SdvdO8EKEezDMjuzqv69Yw==",
-			"requires": {
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/chacha": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/xchacha20poly1305": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/xchacha20poly1305/-/xchacha20poly1305-1.0.0.tgz",
-			"integrity": "sha512-rVcKmgEeMK8kInx2bvvBXLL/wMKrqeA6luWiZYRQj1QMnZnq3ReZd1szZdz2QWFQOlp7rXsZp+EaM4FqNlfZSw==",
-			"requires": {
-				"@stablelib/aead": "^1.0.0",
-				"@stablelib/chacha20poly1305": "^1.0.0",
-				"@stablelib/constant-time": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0",
-				"@stablelib/xchacha20": "^1.0.0"
-			}
-		},
-		"@transmute/did-key-bls12381": {
-			"version": "0.2.1-unstable.37",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-bls12381/-/did-key-bls12381-0.2.1-unstable.37.tgz",
-			"integrity": "sha512-GaivvSQxjdTSbXaMrumBckd7G/m+M/EUSGoiBeUWXiqoQvbqAHESe9c7BiRrDdeIzZ+f/xISv1AB2KOJShujNA==",
-			"requires": {
-				"@mattrglobal/bbs-signatures": "0.4.0",
-				"@mattrglobal/bls12381-key-pair": "^0.5.1-unstable.e779976",
-				"base64url": "^3.0.1",
-				"bs58": "^4.0.1"
-			}
-		},
-		"@transmute/did-key-cipher": {
-			"version": "0.2.1-unstable.37",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-cipher/-/did-key-cipher-0.2.1-unstable.37.tgz",
-			"integrity": "sha512-fEIfTUMo8XIDs7JJA0LIsgMkm4295YFb4qhA2zdpZBr/E5sA+GKJyK7DlUg8HTYH3hXjBGFyGO/j6xYr4xrTxA==",
-			"requires": {
-				"@peculiar/webcrypto": "^1.1.3",
-				"@stablelib/aes-kw": "^1.0.0",
-				"@stablelib/xchacha20poly1305": "^1.0.0",
-				"@transmute/did-key-common": "^0.2.1-unstable.37",
-				"web-streams-polyfill": "^3.0.0"
-			}
-		},
-		"@transmute/did-key-common": {
-			"version": "0.2.1-unstable.37",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-common/-/did-key-common-0.2.1-unstable.37.tgz",
-			"integrity": "sha512-oywMi4xQH1F1h2pJ9DNRZFyEWsy0R/R7dbeQHVz4W2gGJNQADY2pskk7atlvupAuU8n3SqlLkSn672YWGZlU7w==",
-			"requires": {
-				"base64url": "^3.0.1",
-				"borc": "^2.1.2",
-				"canonicalize": "^1.0.3",
-				"cbor": "^5.1.0"
-			}
-		},
-		"@transmute/did-key-ed25519": {
-			"version": "0.2.1-unstable.37",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-ed25519/-/did-key-ed25519-0.2.1-unstable.37.tgz",
-			"integrity": "sha512-subU+Hi3ICdoPBxZQ0M7C26HddNWLiNYjVoABvgkChZYpyVwAc25xsY72shLcxQlOz+FQh1ykeAb3qHsMwFHYA==",
-			"requires": {
-				"@stablelib/ed25519": "^1.0.1",
-				"@transmute/did-key-common": "^0.2.1-unstable.37",
-				"@transmute/did-key-x25519": "^0.2.1-unstable.37",
-				"@trust/keyto": "^1.0.1",
-				"base64url": "^3.0.1",
-				"bs58": "^4.0.1",
-				"canonicalize": "^1.0.1"
-			}
-		},
-		"@transmute/did-key-secp256k1": {
-			"version": "0.2.1-unstable.37",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-secp256k1/-/did-key-secp256k1-0.2.1-unstable.37.tgz",
-			"integrity": "sha512-CGn4CCk7X1IWB8zOM/9iSgBv6enrUbuOZRckiuakNT94ziJ/mbhqDGkidMAksRyQtw8UwL6e27JftjdKf4ErTg==",
-			"requires": {
-				"@transmute/did-key-common": "^0.2.1-unstable.37",
-				"@trust/keyto": "^1.0.1",
-				"base64url": "^3.0.1",
-				"bs58": "^4.0.1",
-				"canonicalize": "^1.0.1",
-				"secp256k1": "^4.0.1"
-			}
-		},
-		"@transmute/did-key-test-vectors": {
-			"version": "0.2.1-unstable.37",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-test-vectors/-/did-key-test-vectors-0.2.1-unstable.37.tgz",
-			"integrity": "sha512-/v1+AEjd6lrqKxnYomtQ03Q4F6nePXF4G8LvNn9ncEd69Xvgg3O7pfI7BHjcPd3X6AcmQhHxOk5BHEzuUxZ1yQ==",
-			"dev": true
-		},
-		"@transmute/did-key-web-crypto": {
-			"version": "0.2.1-unstable.37",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-web-crypto/-/did-key-web-crypto-0.2.1-unstable.37.tgz",
-			"integrity": "sha512-8k3dZWURjreTjmTMvQl0InybfaGRvMEvnyvtQWx74tmtt3TZTkuatG4GY8sNjg4AD1n2BtuT7wZ7//LkfAbKfg==",
-			"requires": {
-				"@transmute/web-crypto-key-pair": "^0.0.4-unstable.13"
-			}
-		},
-		"@transmute/did-key-x25519": {
-			"version": "0.2.1-unstable.37",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-x25519/-/did-key-x25519-0.2.1-unstable.37.tgz",
-			"integrity": "sha512-sSBpiICDTEckJwMGxR83rqVR4S+6NTUet+S3VjXla/GZbT54oWgJu8uPmhUuyupxKrNyL5XbCdzp7BCZW6PJNg==",
-			"requires": {
-				"@stablelib/ed25519": "^1.0.1",
-				"@stablelib/x25519": "^1.0.0",
-				"@transmute/did-key-cipher": "^0.2.1-unstable.37",
-				"@transmute/did-key-common": "^0.2.1-unstable.37",
-				"@trust/keyto": "^1.0.1",
-				"base64url": "^3.0.1",
-				"bs58": "^4.0.1",
-				"canonicalize": "^1.0.1"
-			}
-		},
-		"@transmute/web-crypto-key-pair": {
-			"version": "0.0.4-unstable.17",
-			"resolved": "https://registry.npmjs.org/@transmute/web-crypto-key-pair/-/web-crypto-key-pair-0.0.4-unstable.17.tgz",
-			"integrity": "sha512-xowgLFfGmoZ/OHJS3U+6e5y9+3cjBeJDiedJbDXuo1b/DhaUaDgk5vlr+DFGGNRduCAKPr6Z5KRxOychGBoSbg=="
-		},
-		"@trust/keyto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@trust/keyto/-/keyto-1.0.1.tgz",
-			"integrity": "sha512-OXTmKkrnkwktCX86XA7eWs1TQ6u64enm0syzAfNhjigbuGLy5aLhbhRYWtjt4zzdG/irWudluheRZ9Ic9pCwsA==",
-			"requires": {
-				"asn1.js": "^5.2.0",
-				"base64url": "^3.0.1",
-				"elliptic": "^6.5.2"
-			}
-		},
-		"@types/asn1js": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@types/asn1js/-/asn1js-2.0.0.tgz",
-			"integrity": "sha512-Jjzp5EqU0hNpADctc/UqhiFbY1y2MqIxBVa2S4dBlbnZHTLPMuggoL5q43X63LpsOIINRDirBjP56DUUKIUWIA=="
 		},
 		"@types/babel__core": {
 			"version": "7.1.10",
@@ -1934,12 +1566,6 @@
 			"integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
 			"dev": true
 		},
-		"abbrev": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-			"optional": true
-		},
 		"acorn": {
 			"version": "7.4.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
@@ -1994,23 +1620,6 @@
 			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
 			"dev": true
 		},
-		"ansi-escape-sequences": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.1.0.tgz",
-			"integrity": "sha512-dzW9kHxH011uBsidTXd14JXgzye/YLb2LzeKZ4bsgl/Knwx8AtbSFkkGxagdNOoh0DlqHCmfiEjWKBaqjOanVw==",
-			"optional": true,
-			"requires": {
-				"array-back": "^3.0.1"
-			},
-			"dependencies": {
-				"array-back": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-					"integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-					"optional": true
-				}
-			}
-		},
 		"ansi-escapes": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
@@ -2030,6 +1639,7 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
 			"requires": {
 				"color-convert": "^1.9.0"
 			}
@@ -2042,22 +1652,6 @@
 			"requires": {
 				"micromatch": "^3.1.4",
 				"normalize-path": "^2.1.1"
-			}
-		},
-		"aproba": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-			"optional": true
-		},
-		"are-we-there-yet": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-			"optional": true,
-			"requires": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^2.0.6"
 			}
 		},
 		"argparse": {
@@ -2096,15 +1690,6 @@
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
 			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
 			"dev": true
-		},
-		"array-back": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-			"integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-			"optional": true,
-			"requires": {
-				"typical": "^2.6.1"
-			}
 		},
 		"array-equal": {
 			"version": "1.0.0",
@@ -2220,25 +1805,6 @@
 			"dev": true,
 			"requires": {
 				"safer-buffer": "~2.1.0"
-			}
-		},
-		"asn1.js": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
-			"integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
-			"requires": {
-				"bn.js": "^4.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0",
-				"safer-buffer": "^2.1.0"
-			}
-		},
-		"asn1js": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.1.1.tgz",
-			"integrity": "sha512-t9u0dU0rJN4ML+uxgN6VM2Z4H5jWIYm0w8LsZLzMJaQsgL3IJNbxHgmbWDvJAwspyHpDFuzUaUFh4c05UB4+6g==",
-			"requires": {
-				"pvutils": "^1.0.17"
 			}
 		},
 		"assert-plus": {
@@ -2602,7 +2168,8 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"base": {
 			"version": "0.11.2",
@@ -2659,24 +2226,6 @@
 				}
 			}
 		},
-		"base-x": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
-			"integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"base64-js": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-		},
-		"base64url": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
-			"integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
-		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -2685,11 +2234,6 @@
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
-		},
-		"bignumber.js": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-			"integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
 		},
 		"bindings": {
 			"version": "1.5.0",
@@ -2701,41 +2245,11 @@
 				"file-uri-to-path": "1.0.0"
 			}
 		},
-		"bn.js": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-		},
-		"borc": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
-			"integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
-			"requires": {
-				"bignumber.js": "^9.0.0",
-				"buffer": "^5.5.0",
-				"commander": "^2.15.0",
-				"ieee754": "^1.1.13",
-				"iso-url": "~0.4.7",
-				"json-text-sequence": "~0.1.0",
-				"readable-stream": "^3.6.0"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				}
-			}
-		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -2769,11 +2283,6 @@
 					}
 				}
 			}
-		},
-		"brorand": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
 		},
 		"browser-process-hrtime": {
 			"version": "1.0.0",
@@ -2819,14 +2328,6 @@
 				"fast-json-stable-stringify": "2.x"
 			}
 		},
-		"bs58": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-			"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-			"requires": {
-				"base-x": "^3.0.2"
-			}
-		},
 		"bser": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -2834,15 +2335,6 @@
 			"dev": true,
 			"requires": {
 				"node-int64": "^0.4.0"
-			}
-		},
-		"buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"requires": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
 			}
 		},
 		"buffer-from": {
@@ -2856,12 +2348,6 @@
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
 			"integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
 			"dev": true
-		},
-		"builtins": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-			"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
-			"optional": true
 		},
 		"cache-base": {
 			"version": "1.0.1",
@@ -2908,11 +2394,6 @@
 			"integrity": "sha512-54xKQZTqZrKVHmVz0+UvdZR6kQc7pJDgfhsMYDG19ID1BWoNnDMFm5Q3uSBSU401pBvKYMsHAt9qhEDcxmk8aw==",
 			"dev": true
 		},
-		"canonicalize": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.5.tgz",
-			"integrity": "sha512-mAjKJPIyP0xqqv6IAkvso07StOmz6cmGtNDg3pXCSzXVZOqka7StIkAhJl/zHOi4M2CgpYfD6aeRWbnrmtvBEA=="
-		},
 		"capture-exit": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -2927,15 +2408,6 @@
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 			"dev": true
-		},
-		"cbor": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
-			"integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
-			"requires": {
-				"bignumber.js": "^9.0.1",
-				"nofilter": "^1.0.4"
-			}
 		},
 		"chalk": {
 			"version": "2.4.2",
@@ -2953,12 +2425,6 @@
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
 			"dev": true
-		},
-		"chownr": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-			"optional": true
 		},
 		"ci-info": {
 			"version": "2.0.0",
@@ -3067,12 +2533,6 @@
 			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
 			"dev": true
 		},
-		"code-point-at": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-			"optional": true
-		},
 		"collection-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -3087,6 +2547,7 @@
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -3094,7 +2555,8 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
 		},
 		"combined-stream": {
 			"version": "1.0.8",
@@ -3105,42 +2567,11 @@
 				"delayed-stream": "~1.0.0"
 			}
 		},
-		"command-line-args": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-4.0.7.tgz",
-			"integrity": "sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==",
-			"optional": true,
-			"requires": {
-				"array-back": "^2.0.0",
-				"find-replace": "^1.0.3",
-				"typical": "^2.6.1"
-			}
-		},
-		"command-line-commands": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/command-line-commands/-/command-line-commands-2.0.1.tgz",
-			"integrity": "sha512-m8c2p1DrNd2ruIAggxd/y6DgygQayf6r8RHwchhXryaLF8I6koYjoYroVP+emeROE9DXN5b9sP1Gh+WtvTTdtQ==",
-			"optional": true,
-			"requires": {
-				"array-back": "^2.0.0"
-			}
-		},
-		"command-line-usage": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz",
-			"integrity": "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==",
-			"optional": true,
-			"requires": {
-				"ansi-escape-sequences": "^4.0.0",
-				"array-back": "^2.0.0",
-				"table-layout": "^0.4.2",
-				"typical": "^2.6.1"
-			}
-		},
 		"commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true
 		},
 		"commondir": {
 			"version": "1.0.1",
@@ -3157,19 +2588,14 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"confusing-browser-globals": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz",
 			"integrity": "sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==",
 			"dev": true
-		},
-		"console-control-strings": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-			"optional": true
 		},
 		"contains-path": {
 			"version": "0.1.0",
@@ -3225,7 +2651,8 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"cosmiconfig": {
 			"version": "6.0.0",
@@ -3336,12 +2763,6 @@
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
 		},
-		"deep-extend": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-			"optional": true
-		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -3413,23 +2834,6 @@
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 			"dev": true
 		},
-		"delegates": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-			"optional": true
-		},
-		"delimit-stream": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-			"integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
-		},
-		"detect-libc": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-			"optional": true
-		},
 		"detect-newline": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
@@ -3475,20 +2879,6 @@
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.573.tgz",
 			"integrity": "sha512-oypaNmexr8w0m2GX67fGLQ0Xgsd7uXz7GcwaHZ9eW3ZdQ8uA2+V/wXmLdMTk3gcacbqQGAN7CXWG3fOkfKYftw==",
 			"dev": true
-		},
-		"elliptic": {
-			"version": "6.5.4",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-			"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-			"requires": {
-				"bn.js": "^4.11.9",
-				"brorand": "^1.1.0",
-				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.1",
-				"inherits": "^2.0.4",
-				"minimalistic-assert": "^1.0.1",
-				"minimalistic-crypto-utils": "^1.0.1"
-			}
 		},
 		"emoji-regex": {
 			"version": "8.0.0",
@@ -3563,7 +2953,8 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"escodegen": {
 			"version": "1.14.3",
@@ -4387,27 +3778,6 @@
 				}
 			}
 		},
-		"find-replace": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
-			"integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
-			"optional": true,
-			"requires": {
-				"array-back": "^1.0.4",
-				"test-value": "^2.1.0"
-			},
-			"dependencies": {
-				"array-back": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-					"integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-					"optional": true,
-					"requires": {
-						"typical": "^2.6.0"
-					}
-				}
-			}
-		},
 		"find-up": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -4477,19 +3847,11 @@
 				"universalify": "^0.1.0"
 			}
 		},
-		"fs-minipass": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-			"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
-			"optional": true,
-			"requires": {
-				"minipass": "^2.6.0"
-			}
-		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"fsevents": {
 			"version": "1.2.13",
@@ -4513,44 +3875,6 @@
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
 			"dev": true
-		},
-		"gauge": {
-			"version": "2.7.4",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"optional": true,
-			"requires": {
-				"aproba": "^1.0.3",
-				"console-control-strings": "^1.0.0",
-				"has-unicode": "^2.0.0",
-				"object-assign": "^4.1.0",
-				"signal-exit": "^3.0.0",
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wide-align": "^1.1.0"
-			},
-			"dependencies": {
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"optional": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"optional": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				}
-			}
 		},
 		"gensync": {
 			"version": "1.0.0-beta.1",
@@ -4594,19 +3918,11 @@
 				"assert-plus": "^1.0.0"
 			}
 		},
-		"git-config": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/git-config/-/git-config-0.0.7.tgz",
-			"integrity": "sha1-qcij7wendsPXImE1bYtye2IgKyg=",
-			"optional": true,
-			"requires": {
-				"iniparser": "~1.0.5"
-			}
-		},
 		"glob": {
 			"version": "7.1.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
 			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -4654,27 +3970,6 @@
 			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
 			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
 			"dev": true
-		},
-		"handlebars": {
-			"version": "4.7.7",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-			"integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-			"optional": true,
-			"requires": {
-				"minimist": "^1.2.5",
-				"neo-async": "^2.6.0",
-				"source-map": "^0.6.1",
-				"uglify-js": "^3.1.4",
-				"wordwrap": "^1.0.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"optional": true
-				}
-			}
 		},
 		"har-schema": {
 			"version": "2.0.0",
@@ -4730,12 +4025,6 @@
 			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
 			"dev": true
 		},
-		"has-unicode": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-			"optional": true
-		},
 		"has-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
@@ -4766,25 +4055,6 @@
 						"is-buffer": "^1.1.5"
 					}
 				}
-			}
-		},
-		"hash.js": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-			"requires": {
-				"inherits": "^2.0.3",
-				"minimalistic-assert": "^1.0.1"
-			}
-		},
-		"hmac-drbg": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-			"requires": {
-				"hash.js": "^1.0.3",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
 		"hosted-git-info": {
@@ -4835,29 +4105,16 @@
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
-		},
-		"ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
 		},
 		"ignore": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
 			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
 			"dev": true
-		},
-		"ignore-walk": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-			"integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
-			"optional": true,
-			"requires": {
-				"minimatch": "^3.0.4"
-			}
 		},
 		"import-fresh": {
 			"version": "3.2.1",
@@ -4943,6 +4200,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -4951,19 +4209,8 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-		},
-		"ini": {
-			"version": "1.3.8",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-			"optional": true
-		},
-		"iniparser": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/iniparser/-/iniparser-1.0.5.tgz",
-			"integrity": "sha1-g21r7+bfv87gvM8c+fKsxwJ/eD0=",
-			"optional": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
 		},
 		"inquirer": {
 			"version": "7.3.3",
@@ -5326,18 +4573,14 @@
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 			"dev": true
-		},
-		"iso-url": {
-			"version": "0.4.7",
-			"resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
-			"integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog=="
 		},
 		"isobject": {
 			"version": "3.0.1",
@@ -6075,14 +5318,6 @@
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 			"dev": true
 		},
-		"json-text-sequence": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-			"integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
-			"requires": {
-				"delimit-stream": "0.1.0"
-			}
-		},
 		"json5": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
@@ -6223,7 +5458,8 @@
 		"lodash": {
 			"version": "4.17.20",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+			"dev": true
 		},
 		"lodash.memoize": {
 			"version": "4.1.2",
@@ -6236,12 +5472,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
-		},
-		"lodash.padend": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-			"integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
-			"optional": true
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
@@ -6478,20 +5708,11 @@
 			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
 			"dev": true
 		},
-		"minimalistic-assert": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
-		},
-		"minimalistic-crypto-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
-		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -6499,26 +5720,8 @@
 		"minimist": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-		},
-		"minipass": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-			"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-			"optional": true,
-			"requires": {
-				"safe-buffer": "^5.1.2",
-				"yallist": "^3.0.0"
-			}
-		},
-		"minizlib": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-			"integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
-			"optional": true,
-			"requires": {
-				"minipass": "^2.9.0"
-			}
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+			"dev": true
 		},
 		"mixin-deep": {
 			"version": "1.3.2",
@@ -6545,6 +5748,7 @@
 			"version": "0.5.5",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
 			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
 			}
@@ -6558,7 +5762,8 @@
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
 		},
 		"mute-stream": {
 			"version": "0.0.8",
@@ -6598,223 +5803,6 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
-		"needle": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/needle/-/needle-2.6.0.tgz",
-			"integrity": "sha512-KKYdza4heMsEfSWD7VPUIz3zX2XDwOyX2d+geb4vrERZMT5RMU6ujjaD+I5Yr54uZxQ2w6XRTAhHBbSCyovZBg==",
-			"optional": true,
-			"requires": {
-				"debug": "^3.2.6",
-				"iconv-lite": "^0.4.4",
-				"sax": "^1.2.4"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.7",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-					"optional": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				}
-			}
-		},
-		"neo-async": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-			"optional": true
-		},
-		"neon-cli": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/neon-cli/-/neon-cli-0.4.0.tgz",
-			"integrity": "sha512-66HhHb8rk+zHSG64CI6jhyOQqpibBAald8ObdQPCjXcCjzSEVnkQHutUE8dyNlHRNT7xLfrZGkDbtwrYh2p+6w==",
-			"optional": true,
-			"requires": {
-				"chalk": "~2.1.0",
-				"command-line-args": "^4.0.2",
-				"command-line-commands": "^2.0.0",
-				"command-line-usage": "^4.0.0",
-				"git-config": "0.0.7",
-				"handlebars": "^4.1.0",
-				"inquirer": "^3.0.6",
-				"mkdirp": "^0.5.1",
-				"quickly-copy-file": "^1.0.0",
-				"rimraf": "^2.6.1",
-				"rsvp": "^4.6.1",
-				"semver": "^5.1.0",
-				"toml": "^2.3.0",
-				"ts-typed-json": "^0.2.2",
-				"validate-npm-package-license": "^3.0.1",
-				"validate-npm-package-name": "^3.0.0"
-			},
-			"dependencies": {
-				"ansi-escapes": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-					"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-					"optional": true
-				},
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"optional": true
-				},
-				"chalk": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-					"integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-					"optional": true,
-					"requires": {
-						"ansi-styles": "^3.1.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^4.0.0"
-					}
-				},
-				"chardet": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-					"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-					"optional": true
-				},
-				"cli-cursor": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-					"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-					"optional": true,
-					"requires": {
-						"restore-cursor": "^2.0.0"
-					}
-				},
-				"cli-width": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
-					"integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
-					"optional": true
-				},
-				"external-editor": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-					"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-					"optional": true,
-					"requires": {
-						"chardet": "^0.4.0",
-						"iconv-lite": "^0.4.17",
-						"tmp": "^0.0.33"
-					}
-				},
-				"figures": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-					"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-					"optional": true,
-					"requires": {
-						"escape-string-regexp": "^1.0.5"
-					}
-				},
-				"has-flag": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-					"optional": true
-				},
-				"inquirer": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-					"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-					"optional": true,
-					"requires": {
-						"ansi-escapes": "^3.0.0",
-						"chalk": "^2.0.0",
-						"cli-cursor": "^2.1.0",
-						"cli-width": "^2.0.0",
-						"external-editor": "^2.0.4",
-						"figures": "^2.0.0",
-						"lodash": "^4.3.0",
-						"mute-stream": "0.0.7",
-						"run-async": "^2.2.0",
-						"rx-lite": "^4.0.8",
-						"rx-lite-aggregates": "^4.0.8",
-						"string-width": "^2.1.0",
-						"strip-ansi": "^4.0.0",
-						"through": "^2.3.6"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"optional": true
-				},
-				"mimic-fn": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-					"optional": true
-				},
-				"mute-stream": {
-					"version": "0.0.7",
-					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-					"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-					"optional": true
-				},
-				"onetime": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-					"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-					"optional": true,
-					"requires": {
-						"mimic-fn": "^1.0.0"
-					}
-				},
-				"restore-cursor": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-					"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-					"optional": true,
-					"requires": {
-						"onetime": "^2.0.0",
-						"signal-exit": "^3.0.2"
-					}
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"optional": true
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"optional": true,
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"optional": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-					"optional": true,
-					"requires": {
-						"has-flag": "^2.0.0"
-					}
-				}
-			}
-		},
 		"nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -6829,16 +5817,6 @@
 			"requires": {
 				"lower-case": "^1.1.1"
 			}
-		},
-		"node-addon-api": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-			"integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
-		},
-		"node-gyp-build": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-			"integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
 		},
 		"node-int64": {
 			"version": "0.4.0",
@@ -6873,52 +5851,11 @@
 				}
 			}
 		},
-		"node-pre-gyp": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz",
-			"integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
-			"optional": true,
-			"requires": {
-				"detect-libc": "^1.0.2",
-				"mkdirp": "^0.5.1",
-				"needle": "^2.2.1",
-				"nopt": "^4.0.1",
-				"npm-packlist": "^1.1.6",
-				"npmlog": "^4.0.2",
-				"rc": "^1.2.7",
-				"rimraf": "^2.6.1",
-				"semver": "^5.3.0",
-				"tar": "^4.4.2"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"optional": true
-				}
-			}
-		},
 		"node-releases": {
 			"version": "1.1.61",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.61.tgz",
 			"integrity": "sha512-DD5vebQLg8jLCOzwupn954fbIiZht05DAZs0k2u8NStSe6h9XdsuIQL8hSRKYiU8WUQRznmSDrKGbv3ObOmC7g==",
 			"dev": true
-		},
-		"nofilter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
-			"integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA=="
-		},
-		"nopt": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-			"integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
-			"optional": true,
-			"requires": {
-				"abbrev": "1",
-				"osenv": "^0.1.4"
-			}
 		},
 		"normalize-package-data": {
 			"version": "2.5.0",
@@ -6949,32 +5886,6 @@
 				"remove-trailing-separator": "^1.0.1"
 			}
 		},
-		"npm-bundled": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
-			"integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
-			"optional": true,
-			"requires": {
-				"npm-normalize-package-bin": "^1.0.1"
-			}
-		},
-		"npm-normalize-package-bin": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-			"integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
-			"optional": true
-		},
-		"npm-packlist": {
-			"version": "1.4.8",
-			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
-			"integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
-			"optional": true,
-			"requires": {
-				"ignore-walk": "^3.0.1",
-				"npm-bundled": "^1.0.1",
-				"npm-normalize-package-bin": "^1.0.1"
-			}
-		},
 		"npm-run-path": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -6992,24 +5903,6 @@
 				}
 			}
 		},
-		"npmlog": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"optional": true,
-			"requires": {
-				"are-we-there-yet": "~1.1.2",
-				"console-control-strings": "~1.1.0",
-				"gauge": "~2.7.3",
-				"set-blocking": "~2.0.0"
-			}
-		},
-		"number-is-nan": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-			"optional": true
-		},
 		"nwsapi": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
@@ -7025,7 +5918,8 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
 		},
 		"object-copy": {
 			"version": "0.1.0",
@@ -7233,6 +6127,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -7319,26 +6214,11 @@
 				}
 			}
 		},
-		"os-homedir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-			"optional": true
-		},
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-		},
-		"osenv": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-			"optional": true,
-			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.0"
-			}
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
 		},
 		"p-each-series": {
 			"version": "1.0.0",
@@ -7437,7 +6317,8 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-key": {
 			"version": "2.0.1",
@@ -7538,12 +6419,6 @@
 				"react-is": "^16.8.4"
 			}
 		},
-		"process-nextick-args": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"optional": true
-		},
 		"progress": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -7613,40 +6488,11 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
-		"pvtsutils": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.1.2.tgz",
-			"integrity": "sha512-Yfm9Dsk1zfEpOWCaJaHfqtNXAFWNNHMFSCLN6jTnhuCCBCC2nqge4sAgo7UrkRBoAAYIL8TN/6LlLoNfZD/b5A==",
-			"requires": {
-				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-				}
-			}
-		},
-		"pvutils": {
-			"version": "1.0.17",
-			"resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.0.17.tgz",
-			"integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ=="
-		},
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
 			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
 			"dev": true
-		},
-		"quickly-copy-file": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/quickly-copy-file/-/quickly-copy-file-1.0.0.tgz",
-			"integrity": "sha1-n4/wZiMFEO50IrASFHKwk6hpCFk=",
-			"optional": true,
-			"requires": {
-				"mkdirp": "~0.5.0"
-			}
 		},
 		"randombytes": {
 			"version": "2.1.0",
@@ -7655,26 +6501,6 @@
 			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.0"
-			}
-		},
-		"rc": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-			"optional": true,
-			"requires": {
-				"deep-extend": "^0.6.0",
-				"ini": "~1.3.0",
-				"minimist": "^1.2.0",
-				"strip-json-comments": "~2.0.1"
-			},
-			"dependencies": {
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-					"optional": true
-				}
 			}
 		},
 		"react-is": {
@@ -7715,21 +6541,6 @@
 				"read-pkg": "^2.0.0"
 			}
 		},
-		"readable-stream": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"optional": true,
-			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
 		"realpath-native": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
@@ -7747,12 +6558,6 @@
 			"requires": {
 				"resolve": "^1.1.6"
 			}
-		},
-		"reduce-flatten": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
-			"integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=",
-			"optional": true
 		},
 		"regenerate": {
 			"version": "1.4.1",
@@ -8000,15 +6805,11 @@
 			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
 			"dev": true
 		},
-		"rfc4648": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.4.0.tgz",
-			"integrity": "sha512-3qIzGhHlMHA6PoT6+cdPKZ+ZqtxkIvg8DZGKA5z6PQ33/uuhoJ+Ws/D/J9rXW6gXodgH8QYlz2UCl+sdUDmNIg=="
-		},
 		"rimraf": {
 			"version": "2.6.3",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
 			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
 			}
@@ -8107,27 +6908,14 @@
 		"rsvp": {
 			"version": "4.8.5",
 			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-			"integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
+			"integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+			"dev": true
 		},
 		"run-async": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-			"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
-		},
-		"rx-lite": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-			"optional": true
-		},
-		"rx-lite-aggregates": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-			"optional": true,
-			"requires": {
-				"rx-lite": "*"
-			}
+			"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+			"dev": true
 		},
 		"rxjs": {
 			"version": "6.6.3",
@@ -8158,7 +6946,8 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
 		},
 		"safe-regex": {
 			"version": "1.1.0",
@@ -8172,7 +6961,8 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
 		},
 		"sane": {
 			"version": "4.1.0",
@@ -8241,17 +7031,8 @@
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-		},
-		"secp256k1": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
-			"integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
-			"requires": {
-				"elliptic": "^6.5.2",
-				"node-addon-api": "^2.0.0",
-				"node-gyp-build": "^4.2.0"
-			}
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"dev": true
 		},
 		"semver": {
 			"version": "7.3.2",
@@ -8271,7 +7052,8 @@
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"dev": true
 		},
 		"set-value": {
 			"version": "2.0.1",
@@ -8341,7 +7123,8 @@
 		"signal-exit": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+			"dev": true
 		},
 		"sisteransi": {
 			"version": "1.0.5",
@@ -8549,6 +7332,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
 			"integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
 				"spdx-license-ids": "^3.0.0"
@@ -8557,12 +7341,14 @@
 		"spdx-exceptions": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-			"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
+			"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+			"dev": true
 		},
 		"spdx-expression-parse": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
 			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+			"dev": true,
 			"requires": {
 				"spdx-exceptions": "^2.1.0",
 				"spdx-license-ids": "^3.0.0"
@@ -8571,7 +7357,8 @@
 		"spdx-license-ids": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz",
-			"integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw=="
+			"integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==",
+			"dev": true
 		},
 		"split-string": {
 			"version": "3.1.0",
@@ -8790,18 +7577,11 @@
 				}
 			}
 		},
-		"string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"requires": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
 		"strip-ansi": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			},
@@ -8809,7 +7589,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
 				}
 			}
 		},
@@ -8896,34 +7677,6 @@
 						"ansi-regex": "^4.1.0"
 					}
 				}
-			}
-		},
-		"table-layout": {
-			"version": "0.4.5",
-			"resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.5.tgz",
-			"integrity": "sha512-zTvf0mcggrGeTe/2jJ6ECkJHAQPIYEwDoqsiqBjI24mvRmQbInK5jq33fyypaCBxX08hMkfmdOqj6haT33EqWw==",
-			"optional": true,
-			"requires": {
-				"array-back": "^2.0.0",
-				"deep-extend": "~0.6.0",
-				"lodash.padend": "^4.6.1",
-				"typical": "^2.6.1",
-				"wordwrapjs": "^3.0.0"
-			}
-		},
-		"tar": {
-			"version": "4.4.13",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-			"integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
-			"optional": true,
-			"requires": {
-				"chownr": "^1.1.1",
-				"fs-minipass": "^1.2.5",
-				"minipass": "^2.8.6",
-				"minizlib": "^1.2.1",
-				"mkdirp": "^0.5.0",
-				"safe-buffer": "^5.1.2",
-				"yallist": "^3.0.3"
 			}
 		},
 		"terser": {
@@ -9060,27 +7813,6 @@
 				}
 			}
 		},
-		"test-value": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
-			"integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
-			"optional": true,
-			"requires": {
-				"array-back": "^1.0.3",
-				"typical": "^2.6.0"
-			},
-			"dependencies": {
-				"array-back": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-					"integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-					"optional": true,
-					"requires": {
-						"typical": "^2.6.0"
-					}
-				}
-			}
-		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -9096,7 +7828,8 @@
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
 		},
 		"tiny-glob": {
 			"version": "0.2.6",
@@ -9112,6 +7845,7 @@
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
 			"requires": {
 				"os-tmpdir": "~1.0.2"
 			}
@@ -9170,12 +7904,6 @@
 				"repeat-string": "^1.6.1"
 			}
 		},
-		"toml": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/toml/-/toml-2.3.6.tgz",
-			"integrity": "sha512-gVweAectJU3ebq//Ferr2JUY4WKSDe5N+z0FvjDncLGyHmIDoxgY/2Ie4qfEIDm4IS7OA6Rmdm7pdEEdMcV/xQ==",
-			"optional": true
-		},
 		"tough-cookie": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -9233,23 +7961,6 @@
 					"requires": {
 						"camelcase": "^4.1.0"
 					}
-				}
-			}
-		},
-		"ts-typed-json": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/ts-typed-json/-/ts-typed-json-0.2.2.tgz",
-			"integrity": "sha1-UxhL7ok+RZkbc8jEY6OLWeJ81H4=",
-			"optional": true,
-			"requires": {
-				"rsvp": "^3.5.0"
-			},
-			"dependencies": {
-				"rsvp": {
-					"version": "3.6.2",
-					"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-					"integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-					"optional": true
 				}
 			}
 		},
@@ -9356,7 +8067,8 @@
 		"tslib": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
-			"integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+			"integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
+			"dev": true
 		},
 		"tsutils": {
 			"version": "3.17.1",
@@ -9410,18 +8122,6 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
 			"integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
 			"dev": true
-		},
-		"typical": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-			"integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
-			"optional": true
-		},
-		"uglify-js": {
-			"version": "3.13.4",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.4.tgz",
-			"integrity": "sha512-kv7fCkIXyQIilD5/yQy8O+uagsYIOt5cZvs890W40/e/rvjMSzJw81o9Bg0tkURxzZBROtDQhW2LFjOGoK3RZw==",
-			"optional": true
 		},
 		"unicode-canonical-property-names-ecmascript": {
 			"version": "1.0.4",
@@ -9545,11 +8245,6 @@
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
 			"dev": true
 		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-		},
 		"util.promisify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
@@ -9599,18 +8294,10 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
 			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"dev": true,
 			"requires": {
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
-			}
-		},
-		"validate-npm-package-name": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
-			"integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
-			"optional": true,
-			"requires": {
-				"builtins": "^1.0.3"
 			}
 		},
 		"verror": {
@@ -9649,30 +8336,6 @@
 			"dev": true,
 			"requires": {
 				"defaults": "^1.0.3"
-			}
-		},
-		"web-streams-polyfill": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.0.3.tgz",
-			"integrity": "sha512-d2H/t0eqRNM4w2WvmTdoeIvzAUSpK7JmATB8Nr2lb7nQ9BTIJVjbQ/TRFVEh2gUH1HwclPdoPtfMoFfetXaZnA=="
-		},
-		"webcrypto-core": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.2.0.tgz",
-			"integrity": "sha512-p76Z/YLuE4CHCRdc49FB/ETaM4bzM3roqWNJeGs+QNY1fOTzKTOVnhmudW1fuO+5EZg6/4LG9NJ6gaAyxTk9XQ==",
-			"requires": {
-				"@peculiar/asn1-schema": "^2.0.27",
-				"@peculiar/json-schema": "^1.1.12",
-				"asn1js": "^2.0.26",
-				"pvtsutils": "^1.1.2",
-				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-				}
 			}
 		},
 		"webidl-conversions": {
@@ -9722,69 +8385,11 @@
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 			"dev": true
 		},
-		"wide-align": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-			"optional": true,
-			"requires": {
-				"string-width": "^1.0.2 || 2"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"optional": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"optional": true
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"optional": true,
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"optional": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
-			}
-		},
 		"word-wrap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
 			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
 			"dev": true
-		},
-		"wordwrap": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-			"optional": true
-		},
-		"wordwrapjs": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
-			"integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
-			"optional": true,
-			"requires": {
-				"reduce-flatten": "^1.0.1",
-				"typical": "^2.6.1"
-			}
 		},
 		"wrap-ansi": {
 			"version": "5.1.0",
@@ -9834,7 +8439,8 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write": {
 			"version": "1.0.3",
@@ -9876,12 +8482,6 @@
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
 			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
 			"dev": true
-		},
-		"yallist": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-			"optional": true
 		},
 		"yaml": {
 			"version": "1.10.0",

--- a/packages/did-key.js/package.json
+++ b/packages/did-key.js/package.json
@@ -18,10 +18,10 @@
   },
   "scripts": {
     "start": "tsdx watch",
-    "node15:build": "tsdx build",
-    "node15:test": "tsdx test",
-    "node15:lint": "tsdx lint src --fix",
-    "node15:prepare": "tsdx build"
+    "build": "tsdx build",
+    "test": "tsdx test",
+    "lint": "tsdx lint src --fix",
+    "prepare": "tsdx build"
   },
   "devDependencies": {
     "@transmute/did-key-test-vectors": "^0.2.1-unstable.39",

--- a/packages/did-key.js/src/resolver.test.ts
+++ b/packages/did-key.js/src/resolver.test.ts
@@ -8,7 +8,7 @@ const keyTypes = [
   'bls12381_g1',
   'bls12381_g2',
   'bls12381_g1andg2',
-  // Not supported:
+  // Not supported, see: https://github.com/transmute-industries/did-key.js/issues/73
   // 'p-256',
   // 'p-384',
   // 'p-521'

--- a/packages/did-key.js/src/resolver.test.ts
+++ b/packages/did-key.js/src/resolver.test.ts
@@ -1,7 +1,20 @@
 import { didCoreConformance } from '@transmute/did-key-test-vectors';
 import { resolver } from './resolver';
 
-Object.keys(didCoreConformance).map((k) => {
+const keyTypes = [
+  'ed25519',
+  'x25519',
+  'secp256k1',
+  'bls12381_g1',
+  'bls12381_g2',
+  'bls12381_g1andg2',
+  // Not supported:
+  // 'p-256',
+  // 'p-384',
+  // 'p-521'
+];
+
+keyTypes.map((k) => {
   const keyTypeFixture = didCoreConformance[k].key;
   describe(k, () => {
     keyTypeFixture.forEach((keyFixture: any) => {

--- a/packages/did-key.js/src/resolver.ts
+++ b/packages/did-key.js/src/resolver.ts
@@ -26,14 +26,13 @@ export const resolver = {
     }
     const idchar: any = didUrl.split('did:key:').pop();
     const encodedType = idchar.substring(0, 3);
-    try {
+    if (prefixToDriverMap[encodedType]) {
       const result = await prefixToDriverMap[encodedType].resolve(
         didUrl,
         resolutionMetaData
       );
       return result;
-    } catch (e) {
-      console.error(e);
+    } else {
       throw new Error('Unknown DID Key type: ' + encodedType);
     }
   },

--- a/packages/ed25519/package-lock.json
+++ b/packages/ed25519/package-lock.json
@@ -1310,51 +1310,6 @@
 			"integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==",
 			"dev": true
 		},
-		"@peculiar/asn1-schema": {
-			"version": "2.0.27",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.0.27.tgz",
-			"integrity": "sha512-1tIx7iL3Ma3HtnNS93nB7nhyI0soUJypElj9owd4tpMrRDmeJ8eZubsdq1sb0KSaCs5RqZNoABCP6m5WtnlVhQ==",
-			"requires": {
-				"@types/asn1js": "^2.0.0",
-				"asn1js": "^2.0.26",
-				"pvtsutils": "^1.1.1",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-				}
-			}
-		},
-		"@peculiar/json-schema": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
-			"integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
-			"requires": {
-				"tslib": "^2.0.0"
-			}
-		},
-		"@peculiar/webcrypto": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.1.6.tgz",
-			"integrity": "sha512-xcTjouis4Y117mcsJslWAGypwhxtXslkVdRp7e3tHwtuw0/xCp1te8RuMMv/ia5TsvxomcyX/T+qTbRZGLLvyA==",
-			"requires": {
-				"@peculiar/asn1-schema": "^2.0.27",
-				"@peculiar/json-schema": "^1.1.12",
-				"pvtsutils": "^1.1.2",
-				"tslib": "^2.1.0",
-				"webcrypto-core": "^1.2.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-				}
-			}
-		},
 		"@rollup/plugin-commonjs": {
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-11.1.0.tgz",
@@ -1413,33 +1368,6 @@
 				"picomatch": "^2.2.2"
 			}
 		},
-		"@stablelib/aead": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/aead/-/aead-1.0.0.tgz",
-			"integrity": "sha512-2iO0P15w1onK8g/m6ygNqlMFBfC7BM8o1Zr7jRqMAF9+zhhyY3h4NZwnXKxUm11TBm62Yeesw+FKqs/gJ6shMA=="
-		},
-		"@stablelib/aes": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/aes/-/aes-1.0.0.tgz",
-			"integrity": "sha512-nB6rZxdrbk6dmrHyzEW7u0VOUp1OEYSUmVw8FhAtR6Q91w5MGvwKOpeSoEUWkDLSWy/Hnaem9mV5lzMQJapIig==",
-			"requires": {
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/blockcipher": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/aes-kw": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/aes-kw/-/aes-kw-1.0.0.tgz",
-			"integrity": "sha512-7EYxUFlUbmEaBgVsrunskMpMDSAQL0D6WY4ImzohBGcx8xRR0o+6UiA+EgxTSvSaqnrMK3XmVwnloEl+1YIu7Q==",
-			"requires": {
-				"@stablelib/aes": "^1.0.0",
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/blockcipher": "^1.0.0",
-				"@stablelib/constant-time": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
 		"@stablelib/binary": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.0.tgz",
@@ -1447,43 +1375,6 @@
 			"requires": {
 				"@stablelib/int": "^1.0.0"
 			}
-		},
-		"@stablelib/blockcipher": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/blockcipher/-/blockcipher-1.0.0.tgz",
-			"integrity": "sha512-IQVA3XwCrXb2alpNm4L/MkHkR19f7kH3WmT1oJN6AZWnC7R0vNWKdxnf+4YyHSKisvXThwmyecLMGO+VSdRsDg=="
-		},
-		"@stablelib/bytes": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/bytes/-/bytes-1.0.0.tgz",
-			"integrity": "sha512-c9CfJwoZpxub6yicmhkeEpvLLsvsAP76tBAHEXKuEjPzza946U7bgebJJoMl8Q+ZlU2vy9ZoWCXE1uLpi817Pg=="
-		},
-		"@stablelib/chacha": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/chacha/-/chacha-1.0.0.tgz",
-			"integrity": "sha512-tlp3ECXiU7APq6n1YQ2K4B7MUppAOUWsvN1JMs2OWnYVR2Km+AsSmgMjjtefG8vPZ+J8tfY3sufzh5zCg5xiSw==",
-			"requires": {
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/chacha20poly1305": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/chacha20poly1305/-/chacha20poly1305-1.0.0.tgz",
-			"integrity": "sha512-sRv7T5nDRpwqerY9VZ3ABfzHukF/aa2njKvCHPvMpM3+WOYqU4JIP47MdvmrEj+NFHFP3hBx6XV5xpnV8IqMig==",
-			"requires": {
-				"@stablelib/aead": "^1.0.0",
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/chacha": "^1.0.0",
-				"@stablelib/constant-time": "^1.0.0",
-				"@stablelib/poly1305": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/constant-time": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.0.tgz",
-			"integrity": "sha512-0lH6SB0wP562fa0yvNZMF2NbFr8QHeefhO1KOu2unW8qH1npdep7I1vGbPqEM+BHg6LqllPceVE8Ca0RwIDLDA=="
 		},
 		"@stablelib/ed25519": {
 			"version": "1.0.1",
@@ -1504,23 +1395,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.0.tgz",
 			"integrity": "sha512-MRigEQCO7xM93nZqW4CbIBjhANGw3jJxGVSUZH3PQ6HWL1IGrFWVDBzIclWxl4l5aRRpqoM+76ellQNdUJPnsA=="
-		},
-		"@stablelib/keyagreement": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/keyagreement/-/keyagreement-1.0.0.tgz",
-			"integrity": "sha512-M4f0QhuYGrMCLPoJIKWpC5riJfDivOFZHOAlj1Av44UJSyMzM46gJW0e9khKoTcbU8r8oXebkwlJT70Xm0+kqg==",
-			"requires": {
-				"@stablelib/bytes": "^1.0.0"
-			}
-		},
-		"@stablelib/poly1305": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/poly1305/-/poly1305-1.0.0.tgz",
-			"integrity": "sha512-8EOq8g3Naae+gGI/c/Tt1+xhbgDvkFwYx7QfTlps7SwA/IC6dhEZ+BzvU6O9FuVQ/l72yV7i3PSJ3LMOvTxS8g==",
-			"requires": {
-				"@stablelib/constant-time": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
 		},
 		"@stablelib/random": {
 			"version": "1.0.0",
@@ -1546,82 +1420,6 @@
 			"resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.0.tgz",
 			"integrity": "sha512-0Fd4MQCbEh8OFSO+gG7wBXok7yRC3w+xe/wWM8KNye7EGoHr4BTFZNWV/1xAn2r8/gyFKxPXT8uxXRzDzGq6rg=="
 		},
-		"@stablelib/x25519": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/x25519/-/x25519-1.0.0.tgz",
-			"integrity": "sha512-sjlOzC8eZJhHTuMZnSTxtawYXbFXZtHm6TbhacvoYmJOG9/3cFX5z1Aw0WZfQvPNSk+8aPrpwuyRMmUO1PW8yw==",
-			"requires": {
-				"@stablelib/keyagreement": "^1.0.0",
-				"@stablelib/random": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/xchacha20": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/xchacha20/-/xchacha20-1.0.0.tgz",
-			"integrity": "sha512-8q98HxPCgVUGMnjMl79KhEtWsh0UQbTt5x1570QnynF3uzzsGgP7exXwkyqi7s85SdvdO8EKEezDMjuzqv69Yw==",
-			"requires": {
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/chacha": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/xchacha20poly1305": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/xchacha20poly1305/-/xchacha20poly1305-1.0.0.tgz",
-			"integrity": "sha512-rVcKmgEeMK8kInx2bvvBXLL/wMKrqeA6luWiZYRQj1QMnZnq3ReZd1szZdz2QWFQOlp7rXsZp+EaM4FqNlfZSw==",
-			"requires": {
-				"@stablelib/aead": "^1.0.0",
-				"@stablelib/chacha20poly1305": "^1.0.0",
-				"@stablelib/constant-time": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0",
-				"@stablelib/xchacha20": "^1.0.0"
-			}
-		},
-		"@transmute/did-key-cipher": {
-			"version": "0.2.1-unstable.36",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-cipher/-/did-key-cipher-0.2.1-unstable.36.tgz",
-			"integrity": "sha512-xtGtY8fClgF+q+qfdR7soe/ZOzGaZByeIwanuUhyGjxPNB4NukDQLn18nilqKakitpCoNYsOumHZPkMmLYRTiw==",
-			"requires": {
-				"@peculiar/webcrypto": "^1.1.3",
-				"@stablelib/aes-kw": "^1.0.0",
-				"@stablelib/xchacha20poly1305": "^1.0.0",
-				"@transmute/did-key-common": "^0.2.1-unstable.36",
-				"web-streams-polyfill": "^3.0.0"
-			}
-		},
-		"@transmute/did-key-common": {
-			"version": "0.2.1-unstable.36",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-common/-/did-key-common-0.2.1-unstable.36.tgz",
-			"integrity": "sha512-NvQC5CWPBVh3uj40LrRV2yGCUO9OMR4xeHRqbTxBnyIRwelfE5kL7KZoNo4E7e15Kao4X+evorG94wjBXR8iwA==",
-			"requires": {
-				"base64url": "^3.0.1",
-				"borc": "^2.1.2",
-				"canonicalize": "^1.0.3",
-				"cbor": "^5.1.0"
-			}
-		},
-		"@transmute/did-key-test-vectors": {
-			"version": "0.2.1-unstable.36",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-test-vectors/-/did-key-test-vectors-0.2.1-unstable.36.tgz",
-			"integrity": "sha512-ahe6p2O44CTiOgsyjZLQIZexK3WesGrttjGEO80vlvD9s1HE5/mGkARPS+NTBTME0ima/KRdQYUnFs1cVVNEJg==",
-			"dev": true
-		},
-		"@transmute/did-key-x25519": {
-			"version": "0.2.1-unstable.36",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-x25519/-/did-key-x25519-0.2.1-unstable.36.tgz",
-			"integrity": "sha512-9mVD3EooVn5FI6l7HVRPQxSZb5lc85iddMnRltvz7X9CiB8biY/CDzBWmiKpn9hUjUJHgDBHUQ/AO9IC5fKjxQ==",
-			"requires": {
-				"@stablelib/ed25519": "^1.0.1",
-				"@stablelib/x25519": "^1.0.0",
-				"@transmute/did-key-cipher": "^0.2.1-unstable.36",
-				"@transmute/did-key-common": "^0.2.1-unstable.36",
-				"@trust/keyto": "^1.0.1",
-				"base64url": "^3.0.1",
-				"bs58": "^4.0.1",
-				"canonicalize": "^1.0.1"
-			}
-		},
 		"@trust/keyto": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@trust/keyto/-/keyto-1.0.1.tgz",
@@ -1631,11 +1429,6 @@
 				"base64url": "^3.0.1",
 				"elliptic": "^6.5.2"
 			}
-		},
-		"@types/asn1js": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@types/asn1js/-/asn1js-2.0.0.tgz",
-			"integrity": "sha512-Jjzp5EqU0hNpADctc/UqhiFbY1y2MqIxBVa2S4dBlbnZHTLPMuggoL5q43X63LpsOIINRDirBjP56DUUKIUWIA=="
 		},
 		"@types/babel__core": {
 			"version": "7.1.9",
@@ -2093,14 +1886,6 @@
 				"safer-buffer": "^2.1.0"
 			}
 		},
-		"asn1js": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.1.1.tgz",
-			"integrity": "sha512-t9u0dU0rJN4ML+uxgN6VM2Z4H5jWIYm0w8LsZLzMJaQsgL3IJNbxHgmbWDvJAwspyHpDFuzUaUFh4c05UB4+6g==",
-			"requires": {
-				"pvutils": "^1.0.17"
-			}
-		},
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -2528,11 +2313,6 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
-		"base64-js": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-		},
 		"base64url": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
@@ -2546,11 +2326,6 @@
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
-		},
-		"bignumber.js": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-			"integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
 		},
 		"bindings": {
 			"version": "1.5.0",
@@ -2566,20 +2341,6 @@
 			"version": "4.11.9",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
 			"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-		},
-		"borc": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
-			"integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
-			"requires": {
-				"bignumber.js": "^9.0.0",
-				"buffer": "^5.5.0",
-				"commander": "^2.15.0",
-				"ieee754": "^1.1.13",
-				"iso-url": "~0.4.7",
-				"json-text-sequence": "~0.1.0",
-				"readable-stream": "^3.6.0"
-			}
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -2686,15 +2447,6 @@
 				"node-int64": "^0.4.0"
 			}
 		},
-		"buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"requires": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
-			}
-		},
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -2771,15 +2523,6 @@
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 			"dev": true
-		},
-		"cbor": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
-			"integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
-			"requires": {
-				"bignumber.js": "^9.0.1",
-				"nofilter": "^1.0.4"
-			}
 		},
 		"chalk": {
 			"version": "2.4.2",
@@ -2942,7 +2685,8 @@
 		"commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true
 		},
 		"commondir": {
 			"version": "1.0.1",
@@ -3212,11 +2956,6 @@
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 			"dev": true
-		},
-		"delimit-stream": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-			"integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
 		},
 		"detect-newline": {
 			"version": "2.1.0",
@@ -4527,11 +4266,6 @@
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
-		"ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-		},
 		"ignore": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -5002,11 +4736,6 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 			"dev": true
-		},
-		"iso-url": {
-			"version": "0.4.7",
-			"resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
-			"integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog=="
 		},
 		"isobject": {
 			"version": "3.0.1",
@@ -5753,14 +5482,6 @@
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 			"dev": true
 		},
-		"json-text-sequence": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-			"integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
-			"requires": {
-				"delimit-stream": "0.1.0"
-			}
-		},
 		"json5": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
@@ -6309,11 +6030,6 @@
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.61.tgz",
 			"integrity": "sha512-DD5vebQLg8jLCOzwupn954fbIiZht05DAZs0k2u8NStSe6h9XdsuIQL8hSRKYiU8WUQRznmSDrKGbv3ObOmC7g==",
 			"dev": true
-		},
-		"nofilter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
-			"integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA=="
 		},
 		"normalize-package-data": {
 			"version": "2.5.0",
@@ -6946,26 +6662,6 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
-		"pvtsutils": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.1.2.tgz",
-			"integrity": "sha512-Yfm9Dsk1zfEpOWCaJaHfqtNXAFWNNHMFSCLN6jTnhuCCBCC2nqge4sAgo7UrkRBoAAYIL8TN/6LlLoNfZD/b5A==",
-			"requires": {
-				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-				}
-			}
-		},
-		"pvutils": {
-			"version": "1.0.17",
-			"resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.0.17.tgz",
-			"integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ=="
-		},
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -7017,16 +6713,6 @@
 			"requires": {
 				"find-up": "^2.0.0",
 				"read-pkg": "^2.0.0"
-			}
-		},
-		"readable-stream": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-			"requires": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
 			}
 		},
 		"realpath-native": {
@@ -8063,14 +7749,6 @@
 				}
 			}
 		},
-		"string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"requires": {
-				"safe-buffer": "~5.2.0"
-			}
-		},
 		"strip-ansi": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -8561,7 +8239,8 @@
 		"tslib": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
-			"integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+			"integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
+			"dev": true
 		},
 		"tsutils": {
 			"version": "3.17.1",
@@ -8738,11 +8417,6 @@
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
 			"dev": true
 		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-		},
 		"util.promisify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
@@ -8834,30 +8508,6 @@
 			"dev": true,
 			"requires": {
 				"defaults": "^1.0.3"
-			}
-		},
-		"web-streams-polyfill": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.0.3.tgz",
-			"integrity": "sha512-d2H/t0eqRNM4w2WvmTdoeIvzAUSpK7JmATB8Nr2lb7nQ9BTIJVjbQ/TRFVEh2gUH1HwclPdoPtfMoFfetXaZnA=="
-		},
-		"webcrypto-core": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.2.0.tgz",
-			"integrity": "sha512-p76Z/YLuE4CHCRdc49FB/ETaM4bzM3roqWNJeGs+QNY1fOTzKTOVnhmudW1fuO+5EZg6/4LG9NJ6gaAyxTk9XQ==",
-			"requires": {
-				"@peculiar/asn1-schema": "^2.0.27",
-				"@peculiar/json-schema": "^1.1.12",
-				"asn1js": "^2.0.26",
-				"pvtsutils": "^1.1.2",
-				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-				}
 			}
 		},
 		"webidl-conversions": {

--- a/packages/secp256k1/package-lock.json
+++ b/packages/secp256k1/package-lock.json
@@ -1368,23 +1368,6 @@
 				"picomatch": "^2.2.2"
 			}
 		},
-		"@transmute/did-key-common": {
-			"version": "0.2.1-unstable.36",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-common/-/did-key-common-0.2.1-unstable.36.tgz",
-			"integrity": "sha512-NvQC5CWPBVh3uj40LrRV2yGCUO9OMR4xeHRqbTxBnyIRwelfE5kL7KZoNo4E7e15Kao4X+evorG94wjBXR8iwA==",
-			"requires": {
-				"base64url": "^3.0.1",
-				"borc": "^2.1.2",
-				"canonicalize": "^1.0.3",
-				"cbor": "^5.1.0"
-			}
-		},
-		"@transmute/did-key-test-vectors": {
-			"version": "0.2.1-unstable.36",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-test-vectors/-/did-key-test-vectors-0.2.1-unstable.36.tgz",
-			"integrity": "sha512-ahe6p2O44CTiOgsyjZLQIZexK3WesGrttjGEO80vlvD9s1HE5/mGkARPS+NTBTME0ima/KRdQYUnFs1cVVNEJg==",
-			"dev": true
-		},
 		"@trust/keyto": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@trust/keyto/-/keyto-1.0.1.tgz",
@@ -2278,11 +2261,6 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
-		"base64-js": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-		},
 		"base64url": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
@@ -2296,11 +2274,6 @@
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
-		},
-		"bignumber.js": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-			"integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
 		},
 		"bindings": {
 			"version": "1.5.0",
@@ -2322,20 +2295,6 @@
 			"version": "4.11.9",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
 			"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-		},
-		"borc": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
-			"integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
-			"requires": {
-				"bignumber.js": "^9.0.0",
-				"buffer": "^5.5.0",
-				"commander": "^2.15.0",
-				"ieee754": "^1.1.13",
-				"iso-url": "~0.4.7",
-				"json-text-sequence": "~0.1.0",
-				"readable-stream": "^3.6.0"
-			}
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -2442,15 +2401,6 @@
 				"node-int64": "^0.4.0"
 			}
 		},
-		"buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"requires": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
-			}
-		},
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -2527,15 +2477,6 @@
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 			"dev": true
-		},
-		"cbor": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
-			"integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
-			"requires": {
-				"bignumber.js": "^9.0.1",
-				"nofilter": "^1.0.4"
-			}
 		},
 		"chalk": {
 			"version": "2.4.2",
@@ -2698,7 +2639,8 @@
 		"commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true
 		},
 		"commondir": {
 			"version": "1.0.1",
@@ -2968,11 +2910,6 @@
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 			"dev": true
-		},
-		"delimit-stream": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-			"integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
 		},
 		"detect-newline": {
 			"version": "2.1.0",
@@ -4283,11 +4220,6 @@
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
-		"ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-		},
 		"ignore": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -4758,11 +4690,6 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 			"dev": true
-		},
-		"iso-url": {
-			"version": "0.4.7",
-			"resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
-			"integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog=="
 		},
 		"isobject": {
 			"version": "3.0.1",
@@ -5509,14 +5436,6 @@
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 			"dev": true
 		},
-		"json-text-sequence": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-			"integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
-			"requires": {
-				"delimit-stream": "0.1.0"
-			}
-		},
 		"json5": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
@@ -6075,11 +5994,6 @@
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.61.tgz",
 			"integrity": "sha512-DD5vebQLg8jLCOzwupn954fbIiZht05DAZs0k2u8NStSe6h9XdsuIQL8hSRKYiU8WUQRznmSDrKGbv3ObOmC7g==",
 			"dev": true
-		},
-		"nofilter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
-			"integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA=="
 		},
 		"normalize-package-data": {
 			"version": "2.5.0",
@@ -6763,16 +6677,6 @@
 			"requires": {
 				"find-up": "^2.0.0",
 				"read-pkg": "^2.0.0"
-			}
-		},
-		"readable-stream": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-			"requires": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
 			}
 		},
 		"realpath-native": {
@@ -7819,14 +7723,6 @@
 				}
 			}
 		},
-		"string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"requires": {
-				"safe-buffer": "~5.2.0"
-			}
-		},
 		"strip-ansi": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -8494,11 +8390,6 @@
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
 			"dev": true
-		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"util.promisify": {
 			"version": "1.0.1",

--- a/packages/vc-interop-tests/package-lock.json
+++ b/packages/vc-interop-tests/package-lock.json
@@ -620,40 +620,6 @@
 				"chalk": "^4.0.0"
 			}
 		},
-		"@peculiar/asn1-schema": {
-			"version": "2.0.27",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.0.27.tgz",
-			"integrity": "sha512-1tIx7iL3Ma3HtnNS93nB7nhyI0soUJypElj9owd4tpMrRDmeJ8eZubsdq1sb0KSaCs5RqZNoABCP6m5WtnlVhQ==",
-			"dev": true,
-			"requires": {
-				"@types/asn1js": "^2.0.0",
-				"asn1js": "^2.0.26",
-				"pvtsutils": "^1.1.1",
-				"tslib": "^2.0.3"
-			}
-		},
-		"@peculiar/json-schema": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
-			"integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
-			"dev": true,
-			"requires": {
-				"tslib": "^2.0.0"
-			}
-		},
-		"@peculiar/webcrypto": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.1.6.tgz",
-			"integrity": "sha512-xcTjouis4Y117mcsJslWAGypwhxtXslkVdRp7e3tHwtuw0/xCp1te8RuMMv/ia5TsvxomcyX/T+qTbRZGLLvyA==",
-			"dev": true,
-			"requires": {
-				"@peculiar/asn1-schema": "^2.0.27",
-				"@peculiar/json-schema": "^1.1.12",
-				"pvtsutils": "^1.1.2",
-				"tslib": "^2.1.0",
-				"webcrypto-core": "^1.2.0"
-			}
-		},
 		"@sinonjs/commons": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
@@ -672,257 +638,10 @@
 				"@sinonjs/commons": "^1.7.0"
 			}
 		},
-		"@stablelib/aead": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/aead/-/aead-1.0.0.tgz",
-			"integrity": "sha512-2iO0P15w1onK8g/m6ygNqlMFBfC7BM8o1Zr7jRqMAF9+zhhyY3h4NZwnXKxUm11TBm62Yeesw+FKqs/gJ6shMA==",
-			"dev": true
-		},
-		"@stablelib/aes": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/aes/-/aes-1.0.0.tgz",
-			"integrity": "sha512-nB6rZxdrbk6dmrHyzEW7u0VOUp1OEYSUmVw8FhAtR6Q91w5MGvwKOpeSoEUWkDLSWy/Hnaem9mV5lzMQJapIig==",
-			"dev": true,
-			"requires": {
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/blockcipher": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/aes-kw": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/aes-kw/-/aes-kw-1.0.0.tgz",
-			"integrity": "sha512-7EYxUFlUbmEaBgVsrunskMpMDSAQL0D6WY4ImzohBGcx8xRR0o+6UiA+EgxTSvSaqnrMK3XmVwnloEl+1YIu7Q==",
-			"dev": true,
-			"requires": {
-				"@stablelib/aes": "^1.0.0",
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/blockcipher": "^1.0.0",
-				"@stablelib/constant-time": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/binary": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.0.tgz",
-			"integrity": "sha512-W01QhOw1tWL51Du1c5JZphJs7toRbfra1C2DBlhT0mRHZWGWB1hpFbqiZUFY7QNIMUpmmHLrlZs3YsSCB/giUg==",
-			"dev": true,
-			"requires": {
-				"@stablelib/int": "^1.0.0"
-			}
-		},
-		"@stablelib/blockcipher": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/blockcipher/-/blockcipher-1.0.0.tgz",
-			"integrity": "sha512-IQVA3XwCrXb2alpNm4L/MkHkR19f7kH3WmT1oJN6AZWnC7R0vNWKdxnf+4YyHSKisvXThwmyecLMGO+VSdRsDg==",
-			"dev": true
-		},
-		"@stablelib/bytes": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/bytes/-/bytes-1.0.0.tgz",
-			"integrity": "sha512-c9CfJwoZpxub6yicmhkeEpvLLsvsAP76tBAHEXKuEjPzza946U7bgebJJoMl8Q+ZlU2vy9ZoWCXE1uLpi817Pg==",
-			"dev": true
-		},
-		"@stablelib/chacha": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/chacha/-/chacha-1.0.0.tgz",
-			"integrity": "sha512-tlp3ECXiU7APq6n1YQ2K4B7MUppAOUWsvN1JMs2OWnYVR2Km+AsSmgMjjtefG8vPZ+J8tfY3sufzh5zCg5xiSw==",
-			"dev": true,
-			"requires": {
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/chacha20poly1305": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/chacha20poly1305/-/chacha20poly1305-1.0.0.tgz",
-			"integrity": "sha512-sRv7T5nDRpwqerY9VZ3ABfzHukF/aa2njKvCHPvMpM3+WOYqU4JIP47MdvmrEj+NFHFP3hBx6XV5xpnV8IqMig==",
-			"dev": true,
-			"requires": {
-				"@stablelib/aead": "^1.0.0",
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/chacha": "^1.0.0",
-				"@stablelib/constant-time": "^1.0.0",
-				"@stablelib/poly1305": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/constant-time": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.0.tgz",
-			"integrity": "sha512-0lH6SB0wP562fa0yvNZMF2NbFr8QHeefhO1KOu2unW8qH1npdep7I1vGbPqEM+BHg6LqllPceVE8Ca0RwIDLDA==",
-			"dev": true
-		},
-		"@stablelib/ed25519": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-1.0.1.tgz",
-			"integrity": "sha512-kvC98vkJeertRj37yqTcjOwUVYWQ0jcywxxWpeuTal5ZNgH7EcbljtQYECA2Pi2N0zNG0a0AjSD2Q2DFcUxRjQ==",
-			"dev": true,
-			"requires": {
-				"@stablelib/random": "^1.0.0",
-				"@stablelib/sha512": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/hash": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-1.0.0.tgz",
-			"integrity": "sha512-wBvSIIx4Y8799BRD4TBhezS1P9+irGAKdsNgbZMeU5ndMbw7BtZALdCm0FcJIRFxJ2giPLPS9YCgrwWAhzSRLQ==",
-			"dev": true
-		},
-		"@stablelib/int": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.0.tgz",
-			"integrity": "sha512-MRigEQCO7xM93nZqW4CbIBjhANGw3jJxGVSUZH3PQ6HWL1IGrFWVDBzIclWxl4l5aRRpqoM+76ellQNdUJPnsA==",
-			"dev": true
-		},
-		"@stablelib/keyagreement": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/keyagreement/-/keyagreement-1.0.0.tgz",
-			"integrity": "sha512-M4f0QhuYGrMCLPoJIKWpC5riJfDivOFZHOAlj1Av44UJSyMzM46gJW0e9khKoTcbU8r8oXebkwlJT70Xm0+kqg==",
-			"dev": true,
-			"requires": {
-				"@stablelib/bytes": "^1.0.0"
-			}
-		},
-		"@stablelib/poly1305": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/poly1305/-/poly1305-1.0.0.tgz",
-			"integrity": "sha512-8EOq8g3Naae+gGI/c/Tt1+xhbgDvkFwYx7QfTlps7SwA/IC6dhEZ+BzvU6O9FuVQ/l72yV7i3PSJ3LMOvTxS8g==",
-			"dev": true,
-			"requires": {
-				"@stablelib/constant-time": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/random": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.0.tgz",
-			"integrity": "sha512-G9vwwKrNCGMI/uHL6XeWe2Nk4BuxkYyWZagGaDU9wrsuV+9hUwNI1lok2WVo8uJDa2zx7ahNwN7Ij983hOUFEw==",
-			"dev": true,
-			"requires": {
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/sha512": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/sha512/-/sha512-1.0.0.tgz",
-			"integrity": "sha512-qvUu5SraAdGa8HAkAasfMyD9C+MwlRnFVRJ6cRxAEIekmDsU3tfGLnUm3wb9ao4t0FkihGrj8GKlV82TTR4Phw==",
-			"dev": true,
-			"requires": {
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/hash": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/wipe": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.0.tgz",
-			"integrity": "sha512-0Fd4MQCbEh8OFSO+gG7wBXok7yRC3w+xe/wWM8KNye7EGoHr4BTFZNWV/1xAn2r8/gyFKxPXT8uxXRzDzGq6rg==",
-			"dev": true
-		},
-		"@stablelib/x25519": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/x25519/-/x25519-1.0.0.tgz",
-			"integrity": "sha512-sjlOzC8eZJhHTuMZnSTxtawYXbFXZtHm6TbhacvoYmJOG9/3cFX5z1Aw0WZfQvPNSk+8aPrpwuyRMmUO1PW8yw==",
-			"dev": true,
-			"requires": {
-				"@stablelib/keyagreement": "^1.0.0",
-				"@stablelib/random": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/xchacha20": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/xchacha20/-/xchacha20-1.0.0.tgz",
-			"integrity": "sha512-8q98HxPCgVUGMnjMl79KhEtWsh0UQbTt5x1570QnynF3uzzsGgP7exXwkyqi7s85SdvdO8EKEezDMjuzqv69Yw==",
-			"dev": true,
-			"requires": {
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/chacha": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/xchacha20poly1305": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/xchacha20poly1305/-/xchacha20poly1305-1.0.0.tgz",
-			"integrity": "sha512-rVcKmgEeMK8kInx2bvvBXLL/wMKrqeA6luWiZYRQj1QMnZnq3ReZd1szZdz2QWFQOlp7rXsZp+EaM4FqNlfZSw==",
-			"dev": true,
-			"requires": {
-				"@stablelib/aead": "^1.0.0",
-				"@stablelib/chacha20poly1305": "^1.0.0",
-				"@stablelib/constant-time": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0",
-				"@stablelib/xchacha20": "^1.0.0"
-			}
-		},
 		"@transmute/did-context": {
 			"version": "0.6.1-unstable.13",
 			"resolved": "https://registry.npmjs.org/@transmute/did-context/-/did-context-0.6.1-unstable.13.tgz",
 			"integrity": "sha512-oJImeWeuVH5jSnsIOO4sUhsExHN3P9tlCyGZnsO0GUUivaMIM2bKV3+pA4EUFzCn/vSlQytvRKoiKkjBg4inIg=="
-		},
-		"@transmute/did-key-cipher": {
-			"version": "0.2.1-unstable.37",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-cipher/-/did-key-cipher-0.2.1-unstable.37.tgz",
-			"integrity": "sha512-fEIfTUMo8XIDs7JJA0LIsgMkm4295YFb4qhA2zdpZBr/E5sA+GKJyK7DlUg8HTYH3hXjBGFyGO/j6xYr4xrTxA==",
-			"dev": true,
-			"requires": {
-				"@peculiar/webcrypto": "^1.1.3",
-				"@stablelib/aes-kw": "^1.0.0",
-				"@stablelib/xchacha20poly1305": "^1.0.0",
-				"@transmute/did-key-common": "^0.2.1-unstable.37",
-				"web-streams-polyfill": "^3.0.0"
-			}
-		},
-		"@transmute/did-key-common": {
-			"version": "0.2.1-unstable.37",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-common/-/did-key-common-0.2.1-unstable.37.tgz",
-			"integrity": "sha512-oywMi4xQH1F1h2pJ9DNRZFyEWsy0R/R7dbeQHVz4W2gGJNQADY2pskk7atlvupAuU8n3SqlLkSn672YWGZlU7w==",
-			"dev": true,
-			"requires": {
-				"base64url": "^3.0.1",
-				"borc": "^2.1.2",
-				"canonicalize": "^1.0.3",
-				"cbor": "^5.1.0"
-			}
-		},
-		"@transmute/did-key-ed25519": {
-			"version": "0.2.1-unstable.37",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-ed25519/-/did-key-ed25519-0.2.1-unstable.37.tgz",
-			"integrity": "sha512-subU+Hi3ICdoPBxZQ0M7C26HddNWLiNYjVoABvgkChZYpyVwAc25xsY72shLcxQlOz+FQh1ykeAb3qHsMwFHYA==",
-			"dev": true,
-			"requires": {
-				"@stablelib/ed25519": "^1.0.1",
-				"@transmute/did-key-common": "^0.2.1-unstable.37",
-				"@transmute/did-key-x25519": "^0.2.1-unstable.37",
-				"@trust/keyto": "^1.0.1",
-				"base64url": "^3.0.1",
-				"bs58": "^4.0.1",
-				"canonicalize": "^1.0.1"
-			}
-		},
-		"@transmute/did-key-test-vectors": {
-			"version": "0.2.1-unstable.37",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-test-vectors/-/did-key-test-vectors-0.2.1-unstable.37.tgz",
-			"integrity": "sha512-/v1+AEjd6lrqKxnYomtQ03Q4F6nePXF4G8LvNn9ncEd69Xvgg3O7pfI7BHjcPd3X6AcmQhHxOk5BHEzuUxZ1yQ==",
-			"dev": true
-		},
-		"@transmute/did-key-x25519": {
-			"version": "0.2.1-unstable.37",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-x25519/-/did-key-x25519-0.2.1-unstable.37.tgz",
-			"integrity": "sha512-sSBpiICDTEckJwMGxR83rqVR4S+6NTUet+S3VjXla/GZbT54oWgJu8uPmhUuyupxKrNyL5XbCdzp7BCZW6PJNg==",
-			"dev": true,
-			"requires": {
-				"@stablelib/ed25519": "^1.0.1",
-				"@stablelib/x25519": "^1.0.0",
-				"@transmute/did-key-cipher": "^0.2.1-unstable.37",
-				"@transmute/did-key-common": "^0.2.1-unstable.37",
-				"@trust/keyto": "^1.0.1",
-				"base64url": "^3.0.1",
-				"bs58": "^4.0.1",
-				"canonicalize": "^1.0.1"
-			}
 		},
 		"@transmute/ed25519-signature-2018": {
 			"version": "0.1.1-unstable.7",
@@ -983,23 +702,6 @@
 					}
 				}
 			}
-		},
-		"@trust/keyto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@trust/keyto/-/keyto-1.0.1.tgz",
-			"integrity": "sha512-OXTmKkrnkwktCX86XA7eWs1TQ6u64enm0syzAfNhjigbuGLy5aLhbhRYWtjt4zzdG/irWudluheRZ9Ic9pCwsA==",
-			"dev": true,
-			"requires": {
-				"asn1.js": "^5.2.0",
-				"base64url": "^3.0.1",
-				"elliptic": "^6.5.2"
-			}
-		},
-		"@types/asn1js": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@types/asn1js/-/asn1js-2.0.0.tgz",
-			"integrity": "sha512-Jjzp5EqU0hNpADctc/UqhiFbY1y2MqIxBVa2S4dBlbnZHTLPMuggoL5q43X63LpsOIINRDirBjP56DUUKIUWIA==",
-			"dev": true
 		},
 		"@types/babel__core": {
 			"version": "7.1.10",
@@ -1245,27 +947,6 @@
 				"safer-buffer": "~2.1.0"
 			}
 		},
-		"asn1.js": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
-			"integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0",
-				"safer-buffer": "^2.1.0"
-			}
-		},
-		"asn1js": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.1.1.tgz",
-			"integrity": "sha512-t9u0dU0rJN4ML+uxgN6VM2Z4H5jWIYm0w8LsZLzMJaQsgL3IJNbxHgmbWDvJAwspyHpDFuzUaUFh4c05UB4+6g==",
-			"dev": true,
-			"requires": {
-				"pvutils": "^1.0.17"
-			}
-		},
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -1442,12 +1123,6 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
-		"base64-js": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"dev": true
-		},
 		"base64url": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
@@ -1472,33 +1147,6 @@
 				"tweetnacl": "^0.14.3"
 			}
 		},
-		"bignumber.js": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-			"integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
-			"dev": true
-		},
-		"bn.js": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-			"dev": true
-		},
-		"borc": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
-			"integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
-			"dev": true,
-			"requires": {
-				"bignumber.js": "^9.0.0",
-				"buffer": "^5.5.0",
-				"commander": "^2.15.0",
-				"ieee754": "^1.1.13",
-				"iso-url": "~0.4.7",
-				"json-text-sequence": "~0.1.0",
-				"readable-stream": "^3.6.0"
-			}
-		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1517,12 +1165,6 @@
 			"requires": {
 				"fill-range": "^7.0.1"
 			}
-		},
-		"brorand": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
-			"dev": true
 		},
 		"browser-process-hrtime": {
 			"version": "1.0.0",
@@ -1546,16 +1188,6 @@
 			"dev": true,
 			"requires": {
 				"node-int64": "^0.4.0"
-			}
-		},
-		"buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"dev": true,
-			"requires": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
 			}
 		},
 		"buffer-from": {
@@ -1613,16 +1245,6 @@
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 			"dev": true
-		},
-		"cbor": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
-			"integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
-			"dev": true,
-			"requires": {
-				"bignumber.js": "^9.0.1",
-				"nofilter": "^1.0.4"
-			}
 		},
 		"chalk": {
 			"version": "4.1.0",
@@ -1962,12 +1584,6 @@
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 			"dev": true
 		},
-		"delimit-stream": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-			"integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs=",
-			"dev": true
-		},
 		"detect-newline": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -2005,21 +1621,6 @@
 			"requires": {
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
-			}
-		},
-		"elliptic": {
-			"version": "6.5.4",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-			"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.11.9",
-				"brorand": "^1.1.0",
-				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.1",
-				"inherits": "^2.0.4",
-				"minimalistic-assert": "^1.0.1",
-				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
 		"emittery": {
@@ -2596,27 +2197,6 @@
 				}
 			}
 		},
-		"hash.js": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.3",
-				"minimalistic-assert": "^1.0.1"
-			}
-		},
-		"hmac-drbg": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-			"dev": true,
-			"requires": {
-				"hash.js": "^1.0.3",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.1"
-			}
-		},
 		"hosted-git-info": {
 			"version": "2.8.8",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
@@ -2663,12 +2243,6 @@
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
-		},
-		"ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-			"dev": true
 		},
 		"import-local": {
 			"version": "3.0.2",
@@ -2915,12 +2489,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
-		},
-		"iso-url": {
-			"version": "0.4.7",
-			"resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
-			"integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
 			"dev": true
 		},
 		"isobject": {
@@ -3608,15 +3176,6 @@
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 			"dev": true
 		},
-		"json-text-sequence": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-			"integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
-			"dev": true,
-			"requires": {
-				"delimit-stream": "0.1.0"
-			}
-		},
 		"json5": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
@@ -3845,18 +3404,6 @@
 			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
 			"dev": true
 		},
-		"minimalistic-assert": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-			"dev": true
-		},
-		"minimalistic-crypto-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
-			"dev": true
-		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -4007,12 +3554,6 @@
 					}
 				}
 			}
-		},
-		"nofilter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
-			"integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==",
-			"dev": true
 		},
 		"normalize-package-data": {
 			"version": "2.5.0",
@@ -4370,21 +3911,6 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
-		"pvtsutils": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.1.2.tgz",
-			"integrity": "sha512-Yfm9Dsk1zfEpOWCaJaHfqtNXAFWNNHMFSCLN6jTnhuCCBCC2nqge4sAgo7UrkRBoAAYIL8TN/6LlLoNfZD/b5A==",
-			"dev": true,
-			"requires": {
-				"tslib": "^2.1.0"
-			}
-		},
-		"pvutils": {
-			"version": "1.0.17",
-			"resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.0.17.tgz",
-			"integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ==",
-			"dev": true
-		},
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -4436,17 +3962,6 @@
 				"find-up": "^4.1.0",
 				"read-pkg": "^5.2.0",
 				"type-fest": "^0.8.1"
-			}
-		},
-		"readable-stream": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
 			}
 		},
 		"regex-not": {
@@ -5189,15 +4704,6 @@
 				"es-abstract": "^1.17.5"
 			}
 		},
-		"string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "~5.2.0"
-			}
-		},
 		"strip-ansi": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -5349,12 +4855,6 @@
 				"punycode": "^2.1.1"
 			}
 		},
-		"tslib": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-			"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
-			"dev": true
-		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -5479,12 +4979,6 @@
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
 			"dev": true
 		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
-		},
 		"uuid": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -5588,25 +5082,6 @@
 			"dev": true,
 			"requires": {
 				"makeerror": "1.0.x"
-			}
-		},
-		"web-streams-polyfill": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.0.3.tgz",
-			"integrity": "sha512-d2H/t0eqRNM4w2WvmTdoeIvzAUSpK7JmATB8Nr2lb7nQ9BTIJVjbQ/TRFVEh2gUH1HwclPdoPtfMoFfetXaZnA==",
-			"dev": true
-		},
-		"webcrypto-core": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.2.0.tgz",
-			"integrity": "sha512-p76Z/YLuE4CHCRdc49FB/ETaM4bzM3roqWNJeGs+QNY1fOTzKTOVnhmudW1fuO+5EZg6/4LG9NJ6gaAyxTk9XQ==",
-			"dev": true,
-			"requires": {
-				"@peculiar/asn1-schema": "^2.0.27",
-				"@peculiar/json-schema": "^1.1.12",
-				"asn1js": "^2.0.26",
-				"pvtsutils": "^1.1.2",
-				"tslib": "^2.1.0"
 			}
 		},
 		"webidl-conversions": {

--- a/packages/workbench/package-lock.json
+++ b/packages/workbench/package-lock.json
@@ -1523,54 +1523,6 @@
 				"react-is": "^16.8.0"
 			}
 		},
-		"@mattrglobal/bbs-signatures": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@mattrglobal/bbs-signatures/-/bbs-signatures-0.4.0.tgz",
-			"integrity": "sha512-r6ed3N9xO+7AlO6FF2rVksH+HjfLwxZ9eKWHg3saTi5hzhJyehE3Qahj+goddgYD6emzwzrVbawNZDTttMQUKg==",
-			"requires": {
-				"@mattrglobal/node-bbs-signatures": "0.10.0"
-			}
-		},
-		"@mattrglobal/bls12381-key-pair": {
-			"version": "0.5.1-unstable.e779976",
-			"resolved": "https://registry.npmjs.org/@mattrglobal/bls12381-key-pair/-/bls12381-key-pair-0.5.1-unstable.e779976.tgz",
-			"integrity": "sha512-npZhX59wqa6NyqEWFLVRQvnXRJhkESTHGCrvYFhKpesArZbWyLHx6TJKK4DYBjzBL5OWwpPlmB/Da0rMhK9Y8A==",
-			"requires": {
-				"@mattrglobal/bbs-signatures": "0.5.0",
-				"bs58": "4.0.1",
-				"rfc4648": "1.4.0"
-			},
-			"dependencies": {
-				"@mattrglobal/bbs-signatures": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/@mattrglobal/bbs-signatures/-/bbs-signatures-0.5.0.tgz",
-					"integrity": "sha512-4te4TpacAmeCM8aa/kHkU0i1IJwsO1x/Tez6/YLUWg6rK6bfGA1NNO7IBc12u9ETkoTsiU32UmsiYWXcw9QwKQ==",
-					"requires": {
-						"@mattrglobal/node-bbs-signatures": "0.11.0"
-					}
-				},
-				"@mattrglobal/node-bbs-signatures": {
-					"version": "0.11.0",
-					"resolved": "https://registry.npmjs.org/@mattrglobal/node-bbs-signatures/-/node-bbs-signatures-0.11.0.tgz",
-					"integrity": "sha512-V0wcY0ZewrPOiMOrL3wam0oYL1SLbF2ihgAM6JQvLrAKw1MckYiJ8T4vL+nOBs2hf1PA1TZI+USe5mqMWuVKTw==",
-					"optional": true,
-					"requires": {
-						"neon-cli": "0.4.0",
-						"node-pre-gyp": "0.14.0"
-					}
-				}
-			}
-		},
-		"@mattrglobal/node-bbs-signatures": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/@mattrglobal/node-bbs-signatures/-/node-bbs-signatures-0.10.0.tgz",
-			"integrity": "sha512-i2sd61gXQJ0YJZ6JLUnKoQ8w+V39OOh5cdrYv0odnnF00H0a8y9JbSoDbzqEywFGol6oXk2ezFGI/ilU+1R7wQ==",
-			"optional": true,
-			"requires": {
-				"neon-cli": "0.4.0",
-				"node-pre-gyp": "0.14.0"
-			}
-		},
 		"@mrmlnc/readdir-enhanced": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -1584,223 +1536,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
 			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
-		},
-		"@peculiar/asn1-schema": {
-			"version": "2.0.27",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.0.27.tgz",
-			"integrity": "sha512-1tIx7iL3Ma3HtnNS93nB7nhyI0soUJypElj9owd4tpMrRDmeJ8eZubsdq1sb0KSaCs5RqZNoABCP6m5WtnlVhQ==",
-			"requires": {
-				"@types/asn1js": "^2.0.0",
-				"asn1js": "^2.0.26",
-				"pvtsutils": "^1.1.1",
-				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-				}
-			}
-		},
-		"@peculiar/json-schema": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
-			"integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
-			"requires": {
-				"tslib": "^2.0.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-				}
-			}
-		},
-		"@peculiar/webcrypto": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.1.6.tgz",
-			"integrity": "sha512-xcTjouis4Y117mcsJslWAGypwhxtXslkVdRp7e3tHwtuw0/xCp1te8RuMMv/ia5TsvxomcyX/T+qTbRZGLLvyA==",
-			"requires": {
-				"@peculiar/asn1-schema": "^2.0.27",
-				"@peculiar/json-schema": "^1.1.12",
-				"pvtsutils": "^1.1.2",
-				"tslib": "^2.1.0",
-				"webcrypto-core": "^1.2.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-				}
-			}
-		},
-		"@stablelib/aead": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/aead/-/aead-1.0.0.tgz",
-			"integrity": "sha512-2iO0P15w1onK8g/m6ygNqlMFBfC7BM8o1Zr7jRqMAF9+zhhyY3h4NZwnXKxUm11TBm62Yeesw+FKqs/gJ6shMA=="
-		},
-		"@stablelib/aes": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/aes/-/aes-1.0.0.tgz",
-			"integrity": "sha512-nB6rZxdrbk6dmrHyzEW7u0VOUp1OEYSUmVw8FhAtR6Q91w5MGvwKOpeSoEUWkDLSWy/Hnaem9mV5lzMQJapIig==",
-			"requires": {
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/blockcipher": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/aes-kw": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/aes-kw/-/aes-kw-1.0.0.tgz",
-			"integrity": "sha512-7EYxUFlUbmEaBgVsrunskMpMDSAQL0D6WY4ImzohBGcx8xRR0o+6UiA+EgxTSvSaqnrMK3XmVwnloEl+1YIu7Q==",
-			"requires": {
-				"@stablelib/aes": "^1.0.0",
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/blockcipher": "^1.0.0",
-				"@stablelib/constant-time": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/binary": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.0.tgz",
-			"integrity": "sha512-W01QhOw1tWL51Du1c5JZphJs7toRbfra1C2DBlhT0mRHZWGWB1hpFbqiZUFY7QNIMUpmmHLrlZs3YsSCB/giUg==",
-			"requires": {
-				"@stablelib/int": "^1.0.0"
-			}
-		},
-		"@stablelib/blockcipher": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/blockcipher/-/blockcipher-1.0.0.tgz",
-			"integrity": "sha512-IQVA3XwCrXb2alpNm4L/MkHkR19f7kH3WmT1oJN6AZWnC7R0vNWKdxnf+4YyHSKisvXThwmyecLMGO+VSdRsDg=="
-		},
-		"@stablelib/bytes": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/bytes/-/bytes-1.0.0.tgz",
-			"integrity": "sha512-c9CfJwoZpxub6yicmhkeEpvLLsvsAP76tBAHEXKuEjPzza946U7bgebJJoMl8Q+ZlU2vy9ZoWCXE1uLpi817Pg=="
-		},
-		"@stablelib/chacha": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/chacha/-/chacha-1.0.0.tgz",
-			"integrity": "sha512-tlp3ECXiU7APq6n1YQ2K4B7MUppAOUWsvN1JMs2OWnYVR2Km+AsSmgMjjtefG8vPZ+J8tfY3sufzh5zCg5xiSw==",
-			"requires": {
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/chacha20poly1305": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/chacha20poly1305/-/chacha20poly1305-1.0.0.tgz",
-			"integrity": "sha512-sRv7T5nDRpwqerY9VZ3ABfzHukF/aa2njKvCHPvMpM3+WOYqU4JIP47MdvmrEj+NFHFP3hBx6XV5xpnV8IqMig==",
-			"requires": {
-				"@stablelib/aead": "^1.0.0",
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/chacha": "^1.0.0",
-				"@stablelib/constant-time": "^1.0.0",
-				"@stablelib/poly1305": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/constant-time": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.0.tgz",
-			"integrity": "sha512-0lH6SB0wP562fa0yvNZMF2NbFr8QHeefhO1KOu2unW8qH1npdep7I1vGbPqEM+BHg6LqllPceVE8Ca0RwIDLDA=="
-		},
-		"@stablelib/ed25519": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-1.0.1.tgz",
-			"integrity": "sha512-kvC98vkJeertRj37yqTcjOwUVYWQ0jcywxxWpeuTal5ZNgH7EcbljtQYECA2Pi2N0zNG0a0AjSD2Q2DFcUxRjQ==",
-			"requires": {
-				"@stablelib/random": "^1.0.0",
-				"@stablelib/sha512": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/hash": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-1.0.0.tgz",
-			"integrity": "sha512-wBvSIIx4Y8799BRD4TBhezS1P9+irGAKdsNgbZMeU5ndMbw7BtZALdCm0FcJIRFxJ2giPLPS9YCgrwWAhzSRLQ=="
-		},
-		"@stablelib/int": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.0.tgz",
-			"integrity": "sha512-MRigEQCO7xM93nZqW4CbIBjhANGw3jJxGVSUZH3PQ6HWL1IGrFWVDBzIclWxl4l5aRRpqoM+76ellQNdUJPnsA=="
-		},
-		"@stablelib/keyagreement": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/keyagreement/-/keyagreement-1.0.0.tgz",
-			"integrity": "sha512-M4f0QhuYGrMCLPoJIKWpC5riJfDivOFZHOAlj1Av44UJSyMzM46gJW0e9khKoTcbU8r8oXebkwlJT70Xm0+kqg==",
-			"requires": {
-				"@stablelib/bytes": "^1.0.0"
-			}
-		},
-		"@stablelib/poly1305": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/poly1305/-/poly1305-1.0.0.tgz",
-			"integrity": "sha512-8EOq8g3Naae+gGI/c/Tt1+xhbgDvkFwYx7QfTlps7SwA/IC6dhEZ+BzvU6O9FuVQ/l72yV7i3PSJ3LMOvTxS8g==",
-			"requires": {
-				"@stablelib/constant-time": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/random": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.0.tgz",
-			"integrity": "sha512-G9vwwKrNCGMI/uHL6XeWe2Nk4BuxkYyWZagGaDU9wrsuV+9hUwNI1lok2WVo8uJDa2zx7ahNwN7Ij983hOUFEw==",
-			"requires": {
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/sha512": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/sha512/-/sha512-1.0.0.tgz",
-			"integrity": "sha512-qvUu5SraAdGa8HAkAasfMyD9C+MwlRnFVRJ6cRxAEIekmDsU3tfGLnUm3wb9ao4t0FkihGrj8GKlV82TTR4Phw==",
-			"requires": {
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/hash": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/wipe": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.0.tgz",
-			"integrity": "sha512-0Fd4MQCbEh8OFSO+gG7wBXok7yRC3w+xe/wWM8KNye7EGoHr4BTFZNWV/1xAn2r8/gyFKxPXT8uxXRzDzGq6rg=="
-		},
-		"@stablelib/x25519": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/x25519/-/x25519-1.0.0.tgz",
-			"integrity": "sha512-sjlOzC8eZJhHTuMZnSTxtawYXbFXZtHm6TbhacvoYmJOG9/3cFX5z1Aw0WZfQvPNSk+8aPrpwuyRMmUO1PW8yw==",
-			"requires": {
-				"@stablelib/keyagreement": "^1.0.0",
-				"@stablelib/random": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/xchacha20": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/xchacha20/-/xchacha20-1.0.0.tgz",
-			"integrity": "sha512-8q98HxPCgVUGMnjMl79KhEtWsh0UQbTt5x1570QnynF3uzzsGgP7exXwkyqi7s85SdvdO8EKEezDMjuzqv69Yw==",
-			"requires": {
-				"@stablelib/binary": "^1.0.0",
-				"@stablelib/chacha": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0"
-			}
-		},
-		"@stablelib/xchacha20poly1305": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/xchacha20poly1305/-/xchacha20poly1305-1.0.0.tgz",
-			"integrity": "sha512-rVcKmgEeMK8kInx2bvvBXLL/wMKrqeA6luWiZYRQj1QMnZnq3ReZd1szZdz2QWFQOlp7rXsZp+EaM4FqNlfZSw==",
-			"requires": {
-				"@stablelib/aead": "^1.0.0",
-				"@stablelib/chacha20poly1305": "^1.0.0",
-				"@stablelib/constant-time": "^1.0.0",
-				"@stablelib/wipe": "^1.0.0",
-				"@stablelib/xchacha20": "^1.0.0"
-			}
 		},
 		"@svgr/babel-plugin-add-jsx-attribute": {
 			"version": "4.2.0",
@@ -1911,102 +1646,6 @@
 				"loader-utils": "^1.2.3"
 			}
 		},
-		"@transmute/did-key-bls12381": {
-			"version": "0.2.1-unstable.37",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-bls12381/-/did-key-bls12381-0.2.1-unstable.37.tgz",
-			"integrity": "sha512-GaivvSQxjdTSbXaMrumBckd7G/m+M/EUSGoiBeUWXiqoQvbqAHESe9c7BiRrDdeIzZ+f/xISv1AB2KOJShujNA==",
-			"requires": {
-				"@mattrglobal/bbs-signatures": "0.4.0",
-				"@mattrglobal/bls12381-key-pair": "^0.5.1-unstable.e779976",
-				"base64url": "^3.0.1",
-				"bs58": "^4.0.1"
-			}
-		},
-		"@transmute/did-key-cipher": {
-			"version": "0.2.1-unstable.37",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-cipher/-/did-key-cipher-0.2.1-unstable.37.tgz",
-			"integrity": "sha512-fEIfTUMo8XIDs7JJA0LIsgMkm4295YFb4qhA2zdpZBr/E5sA+GKJyK7DlUg8HTYH3hXjBGFyGO/j6xYr4xrTxA==",
-			"requires": {
-				"@peculiar/webcrypto": "^1.1.3",
-				"@stablelib/aes-kw": "^1.0.0",
-				"@stablelib/xchacha20poly1305": "^1.0.0",
-				"@transmute/did-key-common": "^0.2.1-unstable.37",
-				"web-streams-polyfill": "^3.0.0"
-			}
-		},
-		"@transmute/did-key-common": {
-			"version": "0.2.1-unstable.37",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-common/-/did-key-common-0.2.1-unstable.37.tgz",
-			"integrity": "sha512-oywMi4xQH1F1h2pJ9DNRZFyEWsy0R/R7dbeQHVz4W2gGJNQADY2pskk7atlvupAuU8n3SqlLkSn672YWGZlU7w==",
-			"requires": {
-				"base64url": "^3.0.1",
-				"borc": "^2.1.2",
-				"canonicalize": "^1.0.3",
-				"cbor": "^5.1.0"
-			}
-		},
-		"@transmute/did-key-ed25519": {
-			"version": "0.2.1-unstable.37",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-ed25519/-/did-key-ed25519-0.2.1-unstable.37.tgz",
-			"integrity": "sha512-subU+Hi3ICdoPBxZQ0M7C26HddNWLiNYjVoABvgkChZYpyVwAc25xsY72shLcxQlOz+FQh1ykeAb3qHsMwFHYA==",
-			"requires": {
-				"@stablelib/ed25519": "^1.0.1",
-				"@transmute/did-key-common": "^0.2.1-unstable.37",
-				"@transmute/did-key-x25519": "^0.2.1-unstable.37",
-				"@trust/keyto": "^1.0.1",
-				"base64url": "^3.0.1",
-				"bs58": "^4.0.1",
-				"canonicalize": "^1.0.1"
-			}
-		},
-		"@transmute/did-key-secp256k1": {
-			"version": "0.2.1-unstable.37",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-secp256k1/-/did-key-secp256k1-0.2.1-unstable.37.tgz",
-			"integrity": "sha512-CGn4CCk7X1IWB8zOM/9iSgBv6enrUbuOZRckiuakNT94ziJ/mbhqDGkidMAksRyQtw8UwL6e27JftjdKf4ErTg==",
-			"requires": {
-				"@transmute/did-key-common": "^0.2.1-unstable.37",
-				"@trust/keyto": "^1.0.1",
-				"base64url": "^3.0.1",
-				"bs58": "^4.0.1",
-				"canonicalize": "^1.0.1",
-				"secp256k1": "^4.0.1"
-			}
-		},
-		"@transmute/did-key-web-crypto": {
-			"version": "0.2.1-unstable.37",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-web-crypto/-/did-key-web-crypto-0.2.1-unstable.37.tgz",
-			"integrity": "sha512-8k3dZWURjreTjmTMvQl0InybfaGRvMEvnyvtQWx74tmtt3TZTkuatG4GY8sNjg4AD1n2BtuT7wZ7//LkfAbKfg==",
-			"requires": {
-				"@transmute/web-crypto-key-pair": "^0.0.4-unstable.13"
-			}
-		},
-		"@transmute/did-key-x25519": {
-			"version": "0.2.1-unstable.37",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-x25519/-/did-key-x25519-0.2.1-unstable.37.tgz",
-			"integrity": "sha512-sSBpiICDTEckJwMGxR83rqVR4S+6NTUet+S3VjXla/GZbT54oWgJu8uPmhUuyupxKrNyL5XbCdzp7BCZW6PJNg==",
-			"requires": {
-				"@stablelib/ed25519": "^1.0.1",
-				"@stablelib/x25519": "^1.0.0",
-				"@transmute/did-key-cipher": "^0.2.1-unstable.37",
-				"@transmute/did-key-common": "^0.2.1-unstable.37",
-				"@trust/keyto": "^1.0.1",
-				"base64url": "^3.0.1",
-				"bs58": "^4.0.1",
-				"canonicalize": "^1.0.1"
-			}
-		},
-		"@transmute/did-key.js": {
-			"version": "0.2.1-unstable.37",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key.js/-/did-key.js-0.2.1-unstable.37.tgz",
-			"integrity": "sha512-Eq8R/VVvoN1HhjG9PX/x1TE07Oh2sj6EqIH/aaWNqGI8rryRaGQDmWemCAxlQFtpyNGCkNm1EhsgPvIQh0x77w==",
-			"requires": {
-				"@transmute/did-key-bls12381": "^0.2.1-unstable.37",
-				"@transmute/did-key-ed25519": "^0.2.1-unstable.37",
-				"@transmute/did-key-secp256k1": "^0.2.1-unstable.37",
-				"@transmute/did-key-web-crypto": "^0.2.1-unstable.37",
-				"@transmute/did-key-x25519": "^0.2.1-unstable.37"
-			}
-		},
 		"@transmute/ed25519-signature-2018": {
 			"version": "0.1.1-unstable.6",
 			"resolved": "https://registry.npmjs.org/@transmute/ed25519-signature-2018/-/ed25519-signature-2018-0.1.1-unstable.6.tgz",
@@ -2076,26 +1715,6 @@
 					}
 				}
 			}
-		},
-		"@transmute/web-crypto-key-pair": {
-			"version": "0.0.4-unstable.17",
-			"resolved": "https://registry.npmjs.org/@transmute/web-crypto-key-pair/-/web-crypto-key-pair-0.0.4-unstable.17.tgz",
-			"integrity": "sha512-xowgLFfGmoZ/OHJS3U+6e5y9+3cjBeJDiedJbDXuo1b/DhaUaDgk5vlr+DFGGNRduCAKPr6Z5KRxOychGBoSbg=="
-		},
-		"@trust/keyto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@trust/keyto/-/keyto-1.0.1.tgz",
-			"integrity": "sha512-OXTmKkrnkwktCX86XA7eWs1TQ6u64enm0syzAfNhjigbuGLy5aLhbhRYWtjt4zzdG/irWudluheRZ9Ic9pCwsA==",
-			"requires": {
-				"asn1.js": "^5.2.0",
-				"base64url": "^3.0.1",
-				"elliptic": "^6.5.2"
-			}
-		},
-		"@types/asn1js": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@types/asn1js/-/asn1js-2.0.0.tgz",
-			"integrity": "sha512-Jjzp5EqU0hNpADctc/UqhiFbY1y2MqIxBVa2S4dBlbnZHTLPMuggoL5q43X63LpsOIINRDirBjP56DUUKIUWIA=="
 		},
 		"@types/babel__core": {
 			"version": "7.1.10",
@@ -2487,12 +2106,6 @@
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
 			"integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
 		},
-		"abbrev": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-			"optional": true
-		},
 		"accepts": {
 			"version": "1.3.7",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -2658,23 +2271,6 @@
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
 			"integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA=="
 		},
-		"ansi-escape-sequences": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.1.0.tgz",
-			"integrity": "sha512-dzW9kHxH011uBsidTXd14JXgzye/YLb2LzeKZ4bsgl/Knwx8AtbSFkkGxagdNOoh0DlqHCmfiEjWKBaqjOanVw==",
-			"optional": true,
-			"requires": {
-				"array-back": "^3.0.1"
-			},
-			"dependencies": {
-				"array-back": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-					"integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-					"optional": true
-				}
-			}
-		},
 		"ansi-escapes": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
@@ -2722,54 +2318,6 @@
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
 			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
 		},
-		"are-we-there-yet": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-			"optional": true,
-			"requires": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^2.0.6"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-					"optional": true
-				},
-				"readable-stream": {
-					"version": "2.3.7",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"optional": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"optional": true
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"optional": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
-			}
-		},
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -2806,15 +2354,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
 			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
-		},
-		"array-back": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-			"integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-			"optional": true,
-			"requires": {
-				"typical": "^2.6.1"
-			}
 		},
 		"array-equal": {
 			"version": "1.0.0",
@@ -2897,14 +2436,6 @@
 					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
 					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
 				}
-			}
-		},
-		"asn1js": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.1.1.tgz",
-			"integrity": "sha512-t9u0dU0rJN4ML+uxgN6VM2Z4H5jWIYm0w8LsZLzMJaQsgL3IJNbxHgmbWDvJAwspyHpDFuzUaUFh4c05UB4+6g==",
-			"requires": {
-				"pvutils": "^1.0.17"
 			}
 		},
 		"assert": {
@@ -3856,12 +3387,6 @@
 			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
 			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
 		},
-		"builtins": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-			"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
-			"optional": true
-		},
 		"bytes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -3996,15 +3521,6 @@
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-		},
-		"cbor": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
-			"integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
-			"requires": {
-				"bignumber.js": "^9.0.1",
-				"nofilter": "^1.0.4"
-			}
 		},
 		"chalk": {
 			"version": "2.4.2",
@@ -4246,12 +3762,6 @@
 				"q": "^1.1.2"
 			}
 		},
-		"code-point-at": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-			"optional": true
-		},
 		"collection-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -4303,38 +3813,6 @@
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
 			"requires": {
 				"delayed-stream": "~1.0.0"
-			}
-		},
-		"command-line-args": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-4.0.7.tgz",
-			"integrity": "sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==",
-			"optional": true,
-			"requires": {
-				"array-back": "^2.0.0",
-				"find-replace": "^1.0.3",
-				"typical": "^2.6.1"
-			}
-		},
-		"command-line-commands": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/command-line-commands/-/command-line-commands-2.0.1.tgz",
-			"integrity": "sha512-m8c2p1DrNd2ruIAggxd/y6DgygQayf6r8RHwchhXryaLF8I6koYjoYroVP+emeROE9DXN5b9sP1Gh+WtvTTdtQ==",
-			"optional": true,
-			"requires": {
-				"array-back": "^2.0.0"
-			}
-		},
-		"command-line-usage": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz",
-			"integrity": "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==",
-			"optional": true,
-			"requires": {
-				"ansi-escape-sequences": "^4.0.0",
-				"array-back": "^2.0.0",
-				"table-layout": "^0.4.2",
-				"typical": "^2.6.1"
 			}
 		},
 		"commander": {
@@ -4474,12 +3952,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
 			"integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
-		},
-		"console-control-strings": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-			"optional": true
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -5036,12 +4508,6 @@
 				"regexp.prototype.flags": "^1.2.0"
 			}
 		},
-		"deep-extend": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-			"optional": true
-		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -5156,12 +4622,6 @@
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 		},
-		"delegates": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-			"optional": true
-		},
 		"delimit-stream": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
@@ -5185,12 +4645,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
 			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-		},
-		"detect-libc": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-			"optional": true
 		},
 		"detect-newline": {
 			"version": "2.1.0",
@@ -7088,27 +6542,6 @@
 				"pkg-dir": "^3.0.0"
 			}
 		},
-		"find-replace": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
-			"integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
-			"optional": true,
-			"requires": {
-				"array-back": "^1.0.4",
-				"test-value": "^2.1.0"
-			},
-			"dependencies": {
-				"array-back": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-					"integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-					"optional": true,
-					"requires": {
-						"typical": "^2.6.0"
-					}
-				}
-			}
-		},
 		"find-up": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -7388,59 +6821,6 @@
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
 		},
-		"gauge": {
-			"version": "2.7.4",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"optional": true,
-			"requires": {
-				"aproba": "^1.0.3",
-				"console-control-strings": "^1.0.0",
-				"has-unicode": "^2.0.0",
-				"object-assign": "^4.1.0",
-				"signal-exit": "^3.0.0",
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wide-align": "^1.1.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"optional": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"optional": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"optional": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"optional": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				}
-			}
-		},
 		"gensync": {
 			"version": "1.0.0-beta.1",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
@@ -7576,15 +6956,6 @@
 				}
 			}
 		},
-		"git-config": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/git-config/-/git-config-0.0.7.tgz",
-			"integrity": "sha1-qcij7wendsPXImE1bYtye2IgKyg=",
-			"optional": true,
-			"requires": {
-				"iniparser": "~1.0.5"
-			}
-		},
 		"glob": {
 			"version": "7.1.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -7706,27 +7077,6 @@
 			"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
 			"integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg=="
 		},
-		"handlebars": {
-			"version": "4.7.7",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-			"integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-			"optional": true,
-			"requires": {
-				"minimist": "^1.2.5",
-				"neo-async": "^2.6.0",
-				"source-map": "^0.6.1",
-				"uglify-js": "^3.1.4",
-				"wordwrap": "^1.0.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"optional": true
-				}
-			}
-		},
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -7778,12 +7128,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
 			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
-		},
-		"has-unicode": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-			"optional": true
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -8136,15 +7480,6 @@
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
 			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
 		},
-		"ignore-walk": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-			"integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
-			"optional": true,
-			"requires": {
-				"minimatch": "^3.0.4"
-			}
-		},
 		"immer": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/immer/-/immer-1.10.0.tgz",
@@ -8222,12 +7557,6 @@
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
-		},
-		"iniparser": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/iniparser/-/iniparser-1.0.5.tgz",
-			"integrity": "sha1-g21r7+bfv87gvM8c+fKsxwJ/eD0=",
-			"optional": true
 		},
 		"inquirer": {
 			"version": "7.3.3",
@@ -9749,12 +9078,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
 			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
 		},
-		"lodash.padend": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-			"integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
-			"optional": true
-		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -10122,27 +9445,6 @@
 				"minipass": "^3.0.0"
 			}
 		},
-		"minizlib": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-			"integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
-			"optional": true,
-			"requires": {
-				"minipass": "^2.9.0"
-			},
-			"dependencies": {
-				"minipass": {
-					"version": "2.9.0",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-					"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-					"optional": true,
-					"requires": {
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.0"
-					}
-				}
-			}
-		},
 		"mississippi": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
@@ -10281,34 +9583,6 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
 		},
-		"needle": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/needle/-/needle-2.6.0.tgz",
-			"integrity": "sha512-KKYdza4heMsEfSWD7VPUIz3zX2XDwOyX2d+geb4vrERZMT5RMU6ujjaD+I5Yr54uZxQ2w6XRTAhHBbSCyovZBg==",
-			"optional": true,
-			"requires": {
-				"debug": "^3.2.6",
-				"iconv-lite": "^0.4.4",
-				"sax": "^1.2.4"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.7",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-					"optional": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.3",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-					"optional": true
-				}
-			}
-		},
 		"negotiator": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -10318,195 +9592,6 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
-		},
-		"neon-cli": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/neon-cli/-/neon-cli-0.4.0.tgz",
-			"integrity": "sha512-66HhHb8rk+zHSG64CI6jhyOQqpibBAald8ObdQPCjXcCjzSEVnkQHutUE8dyNlHRNT7xLfrZGkDbtwrYh2p+6w==",
-			"optional": true,
-			"requires": {
-				"chalk": "~2.1.0",
-				"command-line-args": "^4.0.2",
-				"command-line-commands": "^2.0.0",
-				"command-line-usage": "^4.0.0",
-				"git-config": "0.0.7",
-				"handlebars": "^4.1.0",
-				"inquirer": "^3.0.6",
-				"mkdirp": "^0.5.1",
-				"quickly-copy-file": "^1.0.0",
-				"rimraf": "^2.6.1",
-				"rsvp": "^4.6.1",
-				"semver": "^5.1.0",
-				"toml": "^2.3.0",
-				"ts-typed-json": "^0.2.2",
-				"validate-npm-package-license": "^3.0.1",
-				"validate-npm-package-name": "^3.0.0"
-			},
-			"dependencies": {
-				"ansi-escapes": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-					"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-					"optional": true
-				},
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"optional": true
-				},
-				"chalk": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-					"integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-					"optional": true,
-					"requires": {
-						"ansi-styles": "^3.1.0",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^4.0.0"
-					}
-				},
-				"chardet": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-					"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-					"optional": true
-				},
-				"cli-cursor": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-					"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-					"optional": true,
-					"requires": {
-						"restore-cursor": "^2.0.0"
-					}
-				},
-				"cli-width": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
-					"integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
-					"optional": true
-				},
-				"external-editor": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-					"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-					"optional": true,
-					"requires": {
-						"chardet": "^0.4.0",
-						"iconv-lite": "^0.4.17",
-						"tmp": "^0.0.33"
-					}
-				},
-				"figures": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-					"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-					"optional": true,
-					"requires": {
-						"escape-string-regexp": "^1.0.5"
-					}
-				},
-				"has-flag": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-					"optional": true
-				},
-				"inquirer": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-					"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-					"optional": true,
-					"requires": {
-						"ansi-escapes": "^3.0.0",
-						"chalk": "^2.0.0",
-						"cli-cursor": "^2.1.0",
-						"cli-width": "^2.0.0",
-						"external-editor": "^2.0.4",
-						"figures": "^2.0.0",
-						"lodash": "^4.3.0",
-						"mute-stream": "0.0.7",
-						"run-async": "^2.2.0",
-						"rx-lite": "^4.0.8",
-						"rx-lite-aggregates": "^4.0.8",
-						"string-width": "^2.1.0",
-						"strip-ansi": "^4.0.0",
-						"through": "^2.3.6"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"optional": true
-				},
-				"mimic-fn": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-					"optional": true
-				},
-				"mute-stream": {
-					"version": "0.0.7",
-					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-					"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-					"optional": true
-				},
-				"onetime": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-					"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-					"optional": true,
-					"requires": {
-						"mimic-fn": "^1.0.0"
-					}
-				},
-				"restore-cursor": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-					"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-					"optional": true,
-					"requires": {
-						"onetime": "^2.0.0",
-						"signal-exit": "^3.0.2"
-					}
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"optional": true
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"optional": true,
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"optional": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-					"optional": true,
-					"requires": {
-						"has-flag": "^2.0.0"
-					}
-				}
-			}
 		},
 		"next-tick": {
 			"version": "1.0.0",
@@ -10527,11 +9612,6 @@
 				"tslib": "^1.10.0"
 			}
 		},
-		"node-addon-api": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-			"integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
-		},
 		"node-fetch": {
 			"version": "1.7.3",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
@@ -10549,7 +9629,8 @@
 		"node-gyp-build": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-			"integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
+			"integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
+			"optional": true
 		},
 		"node-int64": {
 			"version": "0.4.0",
@@ -10674,51 +9755,10 @@
 				}
 			}
 		},
-		"node-pre-gyp": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz",
-			"integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
-			"optional": true,
-			"requires": {
-				"detect-libc": "^1.0.2",
-				"mkdirp": "^0.5.1",
-				"needle": "^2.2.1",
-				"nopt": "^4.0.1",
-				"npm-packlist": "^1.1.6",
-				"npmlog": "^4.0.2",
-				"rc": "^1.2.7",
-				"rimraf": "^2.6.1",
-				"semver": "^5.3.0",
-				"tar": "^4.4.2"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"optional": true
-				}
-			}
-		},
 		"node-releases": {
 			"version": "1.1.61",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.61.tgz",
 			"integrity": "sha512-DD5vebQLg8jLCOzwupn954fbIiZht05DAZs0k2u8NStSe6h9XdsuIQL8hSRKYiU8WUQRznmSDrKGbv3ObOmC7g=="
-		},
-		"nofilter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
-			"integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA=="
-		},
-		"nopt": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-			"integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
-			"optional": true,
-			"requires": {
-				"abbrev": "1",
-				"osenv": "^0.1.4"
-			}
 		},
 		"normalize-package-data": {
 			"version": "2.5.0",
@@ -10762,32 +9802,6 @@
 				"sort-keys": "^1.0.0"
 			}
 		},
-		"npm-bundled": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
-			"integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
-			"optional": true,
-			"requires": {
-				"npm-normalize-package-bin": "^1.0.1"
-			}
-		},
-		"npm-normalize-package-bin": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-			"integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
-			"optional": true
-		},
-		"npm-packlist": {
-			"version": "1.4.8",
-			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
-			"integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
-			"optional": true,
-			"requires": {
-				"ignore-walk": "^3.0.1",
-				"npm-bundled": "^1.0.1",
-				"npm-normalize-package-bin": "^1.0.1"
-			}
-		},
 		"npm-run-path": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -10803,18 +9817,6 @@
 				}
 			}
 		},
-		"npmlog": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"optional": true,
-			"requires": {
-				"are-we-there-yet": "~1.1.2",
-				"console-control-strings": "~1.1.0",
-				"gauge": "~2.7.3",
-				"set-blocking": "~2.0.0"
-			}
-		},
 		"nth-check": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
@@ -10827,12 +9829,6 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
 			"integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
-		},
-		"number-is-nan": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-			"optional": true
 		},
 		"nwsapi": {
 			"version": "2.2.0",
@@ -11083,26 +10079,10 @@
 			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
 			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
 		},
-		"os-homedir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-			"optional": true
-		},
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-		},
-		"osenv": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-			"optional": true,
-			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.0"
-			}
 		},
 		"p-each-series": {
 			"version": "1.0.0",
@@ -12554,26 +11534,6 @@
 			"integrity": "sha1-H+Bk+wrIUfDeYTIKi/eWg2Qi8z4=",
 			"dev": true
 		},
-		"pvtsutils": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.1.2.tgz",
-			"integrity": "sha512-Yfm9Dsk1zfEpOWCaJaHfqtNXAFWNNHMFSCLN6jTnhuCCBCC2nqge4sAgo7UrkRBoAAYIL8TN/6LlLoNfZD/b5A==",
-			"requires": {
-				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-				}
-			}
-		},
-		"pvutils": {
-			"version": "1.0.17",
-			"resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.0.17.tgz",
-			"integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ=="
-		},
 		"q": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -12607,15 +11567,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
 			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
-		},
-		"quickly-copy-file": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/quickly-copy-file/-/quickly-copy-file-1.0.0.tgz",
-			"integrity": "sha1-n4/wZiMFEO50IrASFHKwk6hpCFk=",
-			"optional": true,
-			"requires": {
-				"mkdirp": "~0.5.0"
-			}
 		},
 		"raf": {
 			"version": "3.4.1",
@@ -12662,26 +11613,6 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
 					"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
-				}
-			}
-		},
-		"rc": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-			"optional": true,
-			"requires": {
-				"deep-extend": "^0.6.0",
-				"ini": "~1.3.0",
-				"minimist": "^1.2.0",
-				"strip-json-comments": "~2.0.1"
-			},
-			"dependencies": {
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-					"optional": true
 				}
 			}
 		},
@@ -13378,12 +12309,6 @@
 				"minimatch": "3.0.4"
 			}
 		},
-		"reduce-flatten": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
-			"integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=",
-			"optional": true
-		},
 		"reduce-reducers": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/reduce-reducers/-/reduce-reducers-0.4.3.tgz",
@@ -13801,11 +12726,6 @@
 			"resolved": "https://registry.npmjs.org/rework-visit/-/rework-visit-1.0.0.tgz",
 			"integrity": "sha1-mUWygD8hni96ygCtuLyfZA+ELJo="
 		},
-		"rfc4648": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.4.0.tgz",
-			"integrity": "sha512-3qIzGhHlMHA6PoT6+cdPKZ+ZqtxkIvg8DZGKA5z6PQ33/uuhoJ+Ws/D/J9rXW6gXodgH8QYlz2UCl+sdUDmNIg=="
-		},
 		"rgb-regex": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
@@ -13849,21 +12769,6 @@
 			"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
 			"requires": {
 				"aproba": "^1.1.1"
-			}
-		},
-		"rx-lite": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-			"optional": true
-		},
-		"rx-lite-aggregates": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-			"optional": true,
-			"requires": {
-				"rx-lite": "*"
 			}
 		},
 		"rxjs": {
@@ -13980,16 +12885,6 @@
 				"@types/json-schema": "^7.0.5",
 				"ajv": "^6.12.4",
 				"ajv-keywords": "^3.5.2"
-			}
-		},
-		"secp256k1": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
-			"integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
-			"requires": {
-				"elliptic": "^6.5.2",
-				"node-addon-api": "^2.0.0",
-				"node-gyp-build": "^4.2.0"
 			}
 		},
 		"security-context": {
@@ -15098,59 +13993,10 @@
 				}
 			}
 		},
-		"table-layout": {
-			"version": "0.4.5",
-			"resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.5.tgz",
-			"integrity": "sha512-zTvf0mcggrGeTe/2jJ6ECkJHAQPIYEwDoqsiqBjI24mvRmQbInK5jq33fyypaCBxX08hMkfmdOqj6haT33EqWw==",
-			"optional": true,
-			"requires": {
-				"array-back": "^2.0.0",
-				"deep-extend": "~0.6.0",
-				"lodash.padend": "^4.6.1",
-				"typical": "^2.6.1",
-				"wordwrapjs": "^3.0.0"
-			}
-		},
 		"tapable": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
 			"integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
-		},
-		"tar": {
-			"version": "4.4.13",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-			"integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
-			"optional": true,
-			"requires": {
-				"chownr": "^1.1.1",
-				"fs-minipass": "^1.2.5",
-				"minipass": "^2.8.6",
-				"minizlib": "^1.2.1",
-				"mkdirp": "^0.5.0",
-				"safe-buffer": "^5.1.2",
-				"yallist": "^3.0.3"
-			},
-			"dependencies": {
-				"fs-minipass": {
-					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-					"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
-					"optional": true,
-					"requires": {
-						"minipass": "^2.6.0"
-					}
-				},
-				"minipass": {
-					"version": "2.9.0",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-					"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-					"optional": true,
-					"requires": {
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.0"
-					}
-				}
-			}
 		},
 		"terser": {
 			"version": "4.8.0",
@@ -15266,27 +14112,6 @@
 				"minimatch": "^3.0.4",
 				"read-pkg-up": "^4.0.0",
 				"require-main-filename": "^2.0.0"
-			}
-		},
-		"test-value": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
-			"integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
-			"optional": true,
-			"requires": {
-				"array-back": "^1.0.3",
-				"typical": "^2.6.0"
-			},
-			"dependencies": {
-				"array-back": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-					"integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-					"optional": true,
-					"requires": {
-						"typical": "^2.6.0"
-					}
-				}
 			}
 		},
 		"text-table": {
@@ -15452,12 +14277,6 @@
 			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
 			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
 		},
-		"toml": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/toml/-/toml-2.3.6.tgz",
-			"integrity": "sha512-gVweAectJU3ebq//Ferr2JUY4WKSDe5N+z0FvjDncLGyHmIDoxgY/2Ie4qfEIDm4IS7OA6Rmdm7pdEEdMcV/xQ==",
-			"optional": true
-		},
 		"tough-cookie": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -15488,23 +14307,6 @@
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.1.6.tgz",
 			"integrity": "sha512-CrG5GqAAzMT7144Cl+UIFP7mz/iIhiy+xQ6GGcnjTezhALT02uPMRw7tgDSESgB5MsfKt55+GPWw4ir1kVtMIQ=="
-		},
-		"ts-typed-json": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/ts-typed-json/-/ts-typed-json-0.2.2.tgz",
-			"integrity": "sha1-UxhL7ok+RZkbc8jEY6OLWeJ81H4=",
-			"optional": true,
-			"requires": {
-				"rsvp": "^3.5.0"
-			},
-			"dependencies": {
-				"rsvp": {
-					"version": "3.6.2",
-					"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-					"integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-					"optional": true
-				}
-			}
 		},
 		"tslib": {
 			"version": "1.13.0",
@@ -15580,22 +14382,10 @@
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 		},
-		"typical": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-			"integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
-			"optional": true
-		},
 		"ua-parser-js": {
 			"version": "0.7.22",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
 			"integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q=="
-		},
-		"uglify-js": {
-			"version": "3.13.4",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.4.tgz",
-			"integrity": "sha512-kv7fCkIXyQIilD5/yQy8O+uagsYIOt5cZvs890W40/e/rvjMSzJw81o9Bg0tkURxzZBROtDQhW2LFjOGoK3RZw==",
-			"optional": true
 		},
 		"unicode-canonical-property-names-ecmascript": {
 			"version": "1.0.4",
@@ -15827,15 +14617,6 @@
 				"spdx-expression-parse": "^3.0.0"
 			}
 		},
-		"validate-npm-package-name": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
-			"integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
-			"optional": true,
-			"requires": {
-				"builtins": "^1.0.3"
-			}
-		},
 		"value-equal": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
@@ -16047,30 +14828,6 @@
 			"integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
 			"requires": {
 				"minimalistic-assert": "^1.0.0"
-			}
-		},
-		"web-streams-polyfill": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.0.3.tgz",
-			"integrity": "sha512-d2H/t0eqRNM4w2WvmTdoeIvzAUSpK7JmATB8Nr2lb7nQ9BTIJVjbQ/TRFVEh2gUH1HwclPdoPtfMoFfetXaZnA=="
-		},
-		"webcrypto-core": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.2.0.tgz",
-			"integrity": "sha512-p76Z/YLuE4CHCRdc49FB/ETaM4bzM3roqWNJeGs+QNY1fOTzKTOVnhmudW1fuO+5EZg6/4LG9NJ6gaAyxTk9XQ==",
-			"requires": {
-				"@peculiar/asn1-schema": "^2.0.27",
-				"@peculiar/json-schema": "^1.1.12",
-				"asn1js": "^2.0.26",
-				"pvtsutils": "^1.1.2",
-				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-				}
 			}
 		},
 		"webidl-conversions": {
@@ -16518,68 +15275,10 @@
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 		},
-		"wide-align": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-			"optional": true,
-			"requires": {
-				"string-width": "^1.0.2 || 2"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"optional": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"optional": true
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"optional": true,
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"optional": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
-			}
-		},
 		"word-wrap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
 			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
-		},
-		"wordwrap": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-			"optional": true
-		},
-		"wordwrapjs": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
-			"integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
-			"optional": true,
-			"requires": {
-				"reduce-flatten": "^1.0.1",
-				"typical": "^2.6.1"
-			}
 		},
 		"workbox-background-sync": {
 			"version": "4.3.1",

--- a/packages/workbench/package.json
+++ b/packages/workbench/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "start": "env-cmd -f ./.env.local react-scripts start",
     "eject": "react-scripts eject",
-    "node15:build": "NODE_OPTIONS=--max_old_space_size=8192 react-scripts build && cp ./build/index.html ./build/404.html"
+    "build": "NODE_OPTIONS=--max_old_space_size=8192 react-scripts build && cp ./build/index.html ./build/404.html"
   },
   "browserslist": {
     "production": [

--- a/packages/x25519/package-lock.json
+++ b/packages/x25519/package-lock.json
@@ -1314,6 +1314,7 @@
 			"version": "2.0.17",
 			"resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.0.17.tgz",
 			"integrity": "sha512-7rJD8bR1r6NFE4skDxXsLsFEO3zM2TfjX9wdq5SERoBNEuxGkAJ3uIH84sIMxvDgJtb3cMfLsv8iNpGN0nAWdw==",
+			"dev": true,
 			"requires": {
 				"@types/asn1js": "^0.0.1",
 				"asn1js": "^2.0.26",
@@ -1325,6 +1326,7 @@
 			"version": "1.1.12",
 			"resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
 			"integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+			"dev": true,
 			"requires": {
 				"tslib": "^2.0.0"
 			}
@@ -1333,6 +1335,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.1.3.tgz",
 			"integrity": "sha512-M1mipPJkWzIf92w3T1Vx5ir3kV9c0oWCcLkeh4vNa/3XDEtQ7xxj5NRKyq67NuVNKLH2/0JD1crlLJyqfYbfBA==",
+			"dev": true,
 			"requires": {
 				"@peculiar/asn1-schema": "^2.0.13",
 				"@peculiar/json-schema": "^1.1.12",
@@ -1402,12 +1405,14 @@
 		"@stablelib/aead": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@stablelib/aead/-/aead-1.0.0.tgz",
-			"integrity": "sha512-2iO0P15w1onK8g/m6ygNqlMFBfC7BM8o1Zr7jRqMAF9+zhhyY3h4NZwnXKxUm11TBm62Yeesw+FKqs/gJ6shMA=="
+			"integrity": "sha512-2iO0P15w1onK8g/m6ygNqlMFBfC7BM8o1Zr7jRqMAF9+zhhyY3h4NZwnXKxUm11TBm62Yeesw+FKqs/gJ6shMA==",
+			"dev": true
 		},
 		"@stablelib/aes": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@stablelib/aes/-/aes-1.0.0.tgz",
 			"integrity": "sha512-nB6rZxdrbk6dmrHyzEW7u0VOUp1OEYSUmVw8FhAtR6Q91w5MGvwKOpeSoEUWkDLSWy/Hnaem9mV5lzMQJapIig==",
+			"dev": true,
 			"requires": {
 				"@stablelib/binary": "^1.0.0",
 				"@stablelib/blockcipher": "^1.0.0",
@@ -1418,6 +1423,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@stablelib/aes-kw/-/aes-kw-1.0.0.tgz",
 			"integrity": "sha512-7EYxUFlUbmEaBgVsrunskMpMDSAQL0D6WY4ImzohBGcx8xRR0o+6UiA+EgxTSvSaqnrMK3XmVwnloEl+1YIu7Q==",
+			"dev": true,
 			"requires": {
 				"@stablelib/aes": "^1.0.0",
 				"@stablelib/binary": "^1.0.0",
@@ -1437,7 +1443,8 @@
 		"@stablelib/blockcipher": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@stablelib/blockcipher/-/blockcipher-1.0.0.tgz",
-			"integrity": "sha512-IQVA3XwCrXb2alpNm4L/MkHkR19f7kH3WmT1oJN6AZWnC7R0vNWKdxnf+4YyHSKisvXThwmyecLMGO+VSdRsDg=="
+			"integrity": "sha512-IQVA3XwCrXb2alpNm4L/MkHkR19f7kH3WmT1oJN6AZWnC7R0vNWKdxnf+4YyHSKisvXThwmyecLMGO+VSdRsDg==",
+			"dev": true
 		},
 		"@stablelib/bytes": {
 			"version": "1.0.0",
@@ -1448,6 +1455,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@stablelib/chacha/-/chacha-1.0.0.tgz",
 			"integrity": "sha512-tlp3ECXiU7APq6n1YQ2K4B7MUppAOUWsvN1JMs2OWnYVR2Km+AsSmgMjjtefG8vPZ+J8tfY3sufzh5zCg5xiSw==",
+			"dev": true,
 			"requires": {
 				"@stablelib/binary": "^1.0.0",
 				"@stablelib/wipe": "^1.0.0"
@@ -1457,6 +1465,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@stablelib/chacha20poly1305/-/chacha20poly1305-1.0.0.tgz",
 			"integrity": "sha512-sRv7T5nDRpwqerY9VZ3ABfzHukF/aa2njKvCHPvMpM3+WOYqU4JIP47MdvmrEj+NFHFP3hBx6XV5xpnV8IqMig==",
+			"dev": true,
 			"requires": {
 				"@stablelib/aead": "^1.0.0",
 				"@stablelib/binary": "^1.0.0",
@@ -1469,7 +1478,8 @@
 		"@stablelib/constant-time": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.0.tgz",
-			"integrity": "sha512-0lH6SB0wP562fa0yvNZMF2NbFr8QHeefhO1KOu2unW8qH1npdep7I1vGbPqEM+BHg6LqllPceVE8Ca0RwIDLDA=="
+			"integrity": "sha512-0lH6SB0wP562fa0yvNZMF2NbFr8QHeefhO1KOu2unW8qH1npdep7I1vGbPqEM+BHg6LqllPceVE8Ca0RwIDLDA==",
+			"dev": true
 		},
 		"@stablelib/ed25519": {
 			"version": "1.0.1",
@@ -1503,6 +1513,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@stablelib/poly1305/-/poly1305-1.0.0.tgz",
 			"integrity": "sha512-8EOq8g3Naae+gGI/c/Tt1+xhbgDvkFwYx7QfTlps7SwA/IC6dhEZ+BzvU6O9FuVQ/l72yV7i3PSJ3LMOvTxS8g==",
+			"dev": true,
 			"requires": {
 				"@stablelib/constant-time": "^1.0.0",
 				"@stablelib/wipe": "^1.0.0"
@@ -1668,64 +1679,6 @@
 				}
 			}
 		},
-		"@transmute/did-key-cipher": {
-			"version": "0.2.1-unstable.36",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-cipher/-/did-key-cipher-0.2.1-unstable.36.tgz",
-			"integrity": "sha512-xtGtY8fClgF+q+qfdR7soe/ZOzGaZByeIwanuUhyGjxPNB4NukDQLn18nilqKakitpCoNYsOumHZPkMmLYRTiw==",
-			"requires": {
-				"@peculiar/webcrypto": "^1.1.3",
-				"@stablelib/aes-kw": "^1.0.0",
-				"@stablelib/xchacha20poly1305": "^1.0.0",
-				"@transmute/did-key-common": "^0.2.1-unstable.36",
-				"web-streams-polyfill": "^3.0.0"
-			},
-			"dependencies": {
-				"@stablelib/xchacha20": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/@stablelib/xchacha20/-/xchacha20-1.0.0.tgz",
-					"integrity": "sha512-8q98HxPCgVUGMnjMl79KhEtWsh0UQbTt5x1570QnynF3uzzsGgP7exXwkyqi7s85SdvdO8EKEezDMjuzqv69Yw==",
-					"requires": {
-						"@stablelib/binary": "^1.0.0",
-						"@stablelib/chacha": "^1.0.0",
-						"@stablelib/wipe": "^1.0.0"
-					}
-				},
-				"@stablelib/xchacha20poly1305": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/@stablelib/xchacha20poly1305/-/xchacha20poly1305-1.0.0.tgz",
-					"integrity": "sha512-rVcKmgEeMK8kInx2bvvBXLL/wMKrqeA6luWiZYRQj1QMnZnq3ReZd1szZdz2QWFQOlp7rXsZp+EaM4FqNlfZSw==",
-					"requires": {
-						"@stablelib/aead": "^1.0.0",
-						"@stablelib/chacha20poly1305": "^1.0.0",
-						"@stablelib/constant-time": "^1.0.0",
-						"@stablelib/wipe": "^1.0.0",
-						"@stablelib/xchacha20": "^1.0.0"
-					}
-				},
-				"web-streams-polyfill": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.0.3.tgz",
-					"integrity": "sha512-d2H/t0eqRNM4w2WvmTdoeIvzAUSpK7JmATB8Nr2lb7nQ9BTIJVjbQ/TRFVEh2gUH1HwclPdoPtfMoFfetXaZnA=="
-				}
-			}
-		},
-		"@transmute/did-key-common": {
-			"version": "0.2.1-unstable.36",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-common/-/did-key-common-0.2.1-unstable.36.tgz",
-			"integrity": "sha512-NvQC5CWPBVh3uj40LrRV2yGCUO9OMR4xeHRqbTxBnyIRwelfE5kL7KZoNo4E7e15Kao4X+evorG94wjBXR8iwA==",
-			"requires": {
-				"base64url": "^3.0.1",
-				"borc": "^2.1.2",
-				"canonicalize": "^1.0.3",
-				"cbor": "^5.1.0"
-			}
-		},
-		"@transmute/did-key-test-vectors": {
-			"version": "0.2.1-unstable.36",
-			"resolved": "https://registry.npmjs.org/@transmute/did-key-test-vectors/-/did-key-test-vectors-0.2.1-unstable.36.tgz",
-			"integrity": "sha512-ahe6p2O44CTiOgsyjZLQIZexK3WesGrttjGEO80vlvD9s1HE5/mGkARPS+NTBTME0ima/KRdQYUnFs1cVVNEJg==",
-			"dev": true
-		},
 		"@trust/keyto": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@trust/keyto/-/keyto-1.0.1.tgz",
@@ -1740,6 +1693,7 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/@types/asn1js/-/asn1js-0.0.1.tgz",
 			"integrity": "sha1-74uflwjLFjKhw6nNJ3F8qr55O8I=",
+			"dev": true,
 			"requires": {
 				"@types/pvutils": "*"
 			}
@@ -1864,7 +1818,8 @@
 		"@types/pvutils": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/@types/pvutils/-/pvutils-0.0.2.tgz",
-			"integrity": "sha512-CgQAm7pjyeF3Gnv78ty4RBVIfluB+Td+2DR8iPaU0prF18pkzptHHP+DoKPfpsJYknKsVZyVsJEu5AuGgAqQ5w=="
+			"integrity": "sha512-CgQAm7pjyeF3Gnv78ty4RBVIfluB+Td+2DR8iPaU0prF18pkzptHHP+DoKPfpsJYknKsVZyVsJEu5AuGgAqQ5w==",
+			"dev": true
 		},
 		"@types/resolve": {
 			"version": "0.0.8",
@@ -2237,6 +2192,7 @@
 			"version": "2.0.26",
 			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.0.26.tgz",
 			"integrity": "sha512-yG89F0j9B4B0MKIcFyWWxnpZPLaNTjCj4tkE3fjbAoo0qmpGw0PYYqSbX/4ebnd9Icn8ZgK4K1fvDyEtW1JYtQ==",
+			"dev": true,
 			"requires": {
 				"pvutils": "^1.0.17"
 			}
@@ -2704,7 +2660,9 @@
 		"base64-js": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+			"dev": true,
+			"optional": true
 		},
 		"base64url": {
 			"version": "3.0.1",
@@ -2737,11 +2695,6 @@
 				}
 			}
 		},
-		"bignumber.js": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-			"integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
-		},
 		"bindings": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -2756,20 +2709,6 @@
 			"version": "4.11.9",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
 			"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-		},
-		"borc": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
-			"integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
-			"requires": {
-				"bignumber.js": "^9.0.0",
-				"buffer": "^5.5.0",
-				"commander": "^2.15.0",
-				"ieee754": "^1.1.13",
-				"iso-url": "~0.4.7",
-				"json-text-sequence": "~0.1.0",
-				"readable-stream": "^3.6.0"
-			}
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -2876,15 +2815,6 @@
 				"node-int64": "^0.4.0"
 			}
 		},
-		"buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"requires": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
-			}
-		},
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -2961,15 +2891,6 @@
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 			"dev": true
-		},
-		"cbor": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
-			"integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
-			"requires": {
-				"bignumber.js": "^9.0.1",
-				"nofilter": "^1.0.4"
-			}
 		},
 		"chalk": {
 			"version": "2.4.2",
@@ -3132,7 +3053,8 @@
 		"commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true
 		},
 		"commondir": {
 			"version": "1.0.1",
@@ -3436,11 +3358,6 @@
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 			"dev": true
-		},
-		"delimit-stream": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-			"integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
 		},
 		"detect-newline": {
 			"version": "2.1.0",
@@ -4793,11 +4710,6 @@
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
-		"ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-		},
 		"ignore": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -5275,11 +5187,6 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 			"dev": true
-		},
-		"iso-url": {
-			"version": "0.4.7",
-			"resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
-			"integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog=="
 		},
 		"isobject": {
 			"version": "3.0.1",
@@ -6063,14 +5970,6 @@
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 			"dev": true
 		},
-		"json-text-sequence": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-			"integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
-			"requires": {
-				"delimit-stream": "0.1.0"
-			}
-		},
 		"json5": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
@@ -6733,11 +6632,6 @@
 				"webcrypto-core": "^1.1.6"
 			}
 		},
-		"nofilter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
-			"integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA=="
-		},
 		"normalize-package-data": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -7373,6 +7267,7 @@
 			"version": "1.0.12",
 			"resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.0.12.tgz",
 			"integrity": "sha512-fudCcWFUE7WPHMRVdlEDdeaeLf+8hvZFvfJJ+p8GZlwrrdoiVfv7WZaPt6k7k/NZjMxR8yUbbH51hpwlSmLHiQ==",
+			"dev": true,
 			"requires": {
 				"tslib": "^2.0.1"
 			}
@@ -7380,7 +7275,8 @@
 		"pvutils": {
 			"version": "1.0.17",
 			"resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.0.17.tgz",
-			"integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ=="
+			"integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ==",
+			"dev": true
 		},
 		"qs": {
 			"version": "6.5.2",
@@ -7443,16 +7339,6 @@
 			"requires": {
 				"find-up": "^2.0.0",
 				"read-pkg": "^2.0.0"
-			}
-		},
-		"readable-stream": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-			"requires": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
 			}
 		},
 		"realpath-native": {
@@ -8514,14 +8400,6 @@
 				}
 			}
 		},
-		"string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"requires": {
-				"safe-buffer": "~5.2.0"
-			}
-		},
 		"strip-ansi": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -9021,7 +8899,8 @@
 		"tslib": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
-			"integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+			"integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
+			"dev": true
 		},
 		"tsutils": {
 			"version": "3.17.1",
@@ -9198,11 +9077,6 @@
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
 			"dev": true
 		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-		},
 		"util.promisify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
@@ -9306,6 +9180,7 @@
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.1.8.tgz",
 			"integrity": "sha512-hKnFXsqh0VloojNeTfrwFoRM4MnaWzH6vtXcaFcGjPEu+8HmBdQZnps3/2ikOFqS8bJN1RYr6mI2P/FJzyZnXg==",
+			"dev": true,
 			"requires": {
 				"@peculiar/asn1-schema": "^2.0.12",
 				"@peculiar/json-schema": "^1.1.12",


### PR DESCRIPTION
- remove node 15 commands
- use latest web crypto dependencies that work with node 14
- Update mattr dependencies so that bls tests work in node 14

We are missing support for the P-XXX NIST curves, see: https://github.com/transmute-industries/did-key.js/blob/b0f3e9cbfe77a315a3e5ec931183dc7e7a26eb4b/packages/did-key.js/src/resolver.test.ts#L11